### PR TITLE
Fixed inconsistent implementation of reindex(i_to_v::Fill, j_to_i::AbstractArray)

### DIFF
--- a/src/Arrays/Reindex.jl
+++ b/src/Arrays/Reindex.jl
@@ -8,8 +8,7 @@ end
 
 function reindex(i_to_v::Fill, j_to_i::AbstractArray)
   v = i_to_v.value
-  l = length(j_to_i)
-  Fill(v,l)
+  Fill(v,size(j_to_i)...)
 end
 
 function reindex(i_to_v::CompressedArray, j_to_i::AbstractArray)
@@ -67,4 +66,3 @@ function reindex(i_to_v::AppliedArray, j_to_i::AbstractArray)
 end
 
 Base.getindex(a::AppliedArray,i::AbstractArray) = reindex(a,i)
-

--- a/src/FESpaces/Assemblers.jl
+++ b/src/FESpaces/Assemblers.jl
@@ -166,7 +166,7 @@ function test_assembler(a::Assembler,matdata,vecdata,data)
   @test num_free_dofs(test_fesp) == length(b)
 end
 
-# This is an extended interface that only make sense for assemblers that build (sequential) sparse matrices
+# This is an extended interface that only makes sense for assemblers that build (sequential) sparse matrices
 # (e.g. not for matrix free assemblers or for distributed assemblers)
 
 """
@@ -304,4 +304,3 @@ function test_sparse_matrix_assembler(a::SparseMatrixAssembler,matdata,vecdata,d
   _ = get_matrix_type(a)
   _ = get_vector_type(a)
 end
-

--- a/test/ArraysTests/ReindexTests.jl
+++ b/test/ArraysTests/ReindexTests.jl
@@ -22,6 +22,15 @@ c = reindex(a,b)
 d = a[b]
 test_array(c,d)
 
+a = Fill(1.0,5,5)
+b = [13 23; 15 25]
+
+c = reindex(a,b)
+@test isa(c,Fill)
+
+d = a[b]
+test_array(c,d)
+
 a = CompressedArray([30,40,10,20,30],[1,2,3,5,3,1,4,2])
 b = [3,1,2]
 


### PR DESCRIPTION
In particular, the returned FilledArray, was always a rank-1 array, instead of being of the same rank as j_to_i.

Related to issue #251 