### PR TITLE
Bug fixed `restrict(::AbstractArray,::TriangulationPortion)` for portions of BoundaryTriangulation(s)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
  - Fixed some methods of the `sparsecsr` generic function. Since PR [#262](https://github.com/gridap/Gridap.jl/pull/262).
+ - Fixed `restrict(::AbstractArray,::TriangulationPortion)` for portions of triangulations extending `BoundaryTriangulation`. Since PR [#267](https://github.com/gridap/Gridap.jl/pull/267).
 
 ## [0.10.2] - 2020-5-21
 

--- a/src/Geometry/BoundaryTriangulations.jl
+++ b/src/Geometry/BoundaryTriangulations.jl
@@ -67,6 +67,29 @@ function restrict(f::AbstractArray, trian::BoundaryTriangulation)
   compose_field_arrays(reindex(f,trian), get_face_to_cell_map(trian))
 end
 
+is_portion_of_boundary_triangulation(::TriangulationPortion{Dc,Dp,<:Triangulation}) where {Dc,Dp}=false
+is_portion_of_boundary_triangulation(trian::TriangulationPortion{Dc,Dp,<:TriangulationPortion}) where {Dc,Dp}=
+  is_portion_of_boundary_triangulation(trian.oldtrian)
+is_portion_of_boundary_triangulation(::TriangulationPortion{Dc,Dp,<:BoundaryTriangulation}) where {Dc,Dp}=true
+
+function get_face_to_cell_map(::TriangulationPortion{Dc,Dp,<:Triangulation}) where {Dc,Dp}
+  @assert false "You can only call get_face_to_cell_map with a TriangulationPortion of a BoundaryTriangulation"
+end
+function get_face_to_cell_map(trian::TriangulationPortion{Dc,Dp,<:TriangulationPortion}) where {Dc,Dp}
+  get_face_to_cell_map(trian.oldtrian)
+end
+function get_face_to_cell_map(trian::TriangulationPortion{Dc,Dp,<:BoundaryTriangulation}) where {Dc,Dp}
+  get_face_to_cell_map(trian.oldtrian)
+end
+
+function restrict(f::AbstractArray,trian::TriangulationPortion)
+  if (is_portion_of_boundary_triangulation(trian))
+    compose_field_arrays(reindex(f,trian), reindex(get_face_to_cell_map(trian),trian.cell_to_oldcell))
+  else
+    reindex(f,trian)
+  end
+end
+
 function get_cell_id(trian::BoundaryTriangulation)
   get_face_to_cell(trian)
 end
@@ -131,6 +154,3 @@ end
 #  D = num_cell_dims(model)
 #  face_to_mask = get_face_mask(labeling,tags,D-1)
 #end
-
-
-

--- a/src/Geometry/BoundaryTriangulations.jl
+++ b/src/Geometry/BoundaryTriangulations.jl
@@ -67,29 +67,6 @@ function restrict(f::AbstractArray, trian::BoundaryTriangulation)
   compose_field_arrays(reindex(f,trian), get_face_to_cell_map(trian))
 end
 
-# is_portion_of_boundary_triangulation(::TriangulationPortion{Dc,Dp,<:Triangulation}) where {Dc,Dp}=false
-# is_portion_of_boundary_triangulation(trian::TriangulationPortion{Dc,Dp,<:TriangulationPortion}) where {Dc,Dp}=
-#   is_portion_of_boundary_triangulation(trian.oldtrian)
-# is_portion_of_boundary_triangulation(::TriangulationPortion{Dc,Dp,<:BoundaryTriangulation}) where {Dc,Dp}=true
-#
-# function get_face_to_cell_map(::TriangulationPortion{Dc,Dp,<:Triangulation}) where {Dc,Dp}
-#   @assert false "You can only call get_face_to_cell_map with a TriangulationPortion of a BoundaryTriangulation"
-# end
-# function get_face_to_cell_map(trian::TriangulationPortion{Dc,Dp,<:TriangulationPortion}) where {Dc,Dp}
-#   get_face_to_cell_map(trian.oldtrian)
-# end
-# function get_face_to_cell_map(trian::TriangulationPortion{Dc,Dp,<:BoundaryTriangulation}) where {Dc,Dp}
-#   get_face_to_cell_map(trian.oldtrian)
-# end
-#
-# function restrict(f::AbstractArray,trian::TriangulationPortion)
-#   if (is_portion_of_boundary_triangulation(trian))
-#     compose_field_arrays(reindex(f,trian), reindex(get_face_to_cell_map(trian),trian.cell_to_oldcell))
-#   else
-#     reindex(f,trian)
-#   end
-# end
-
 function get_cell_id(trian::BoundaryTriangulation)
   get_face_to_cell(trian)
 end

--- a/src/Geometry/BoundaryTriangulations.jl
+++ b/src/Geometry/BoundaryTriangulations.jl
@@ -67,28 +67,28 @@ function restrict(f::AbstractArray, trian::BoundaryTriangulation)
   compose_field_arrays(reindex(f,trian), get_face_to_cell_map(trian))
 end
 
-is_portion_of_boundary_triangulation(::TriangulationPortion{Dc,Dp,<:Triangulation}) where {Dc,Dp}=false
-is_portion_of_boundary_triangulation(trian::TriangulationPortion{Dc,Dp,<:TriangulationPortion}) where {Dc,Dp}=
-  is_portion_of_boundary_triangulation(trian.oldtrian)
-is_portion_of_boundary_triangulation(::TriangulationPortion{Dc,Dp,<:BoundaryTriangulation}) where {Dc,Dp}=true
-
-function get_face_to_cell_map(::TriangulationPortion{Dc,Dp,<:Triangulation}) where {Dc,Dp}
-  @assert false "You can only call get_face_to_cell_map with a TriangulationPortion of a BoundaryTriangulation"
-end
-function get_face_to_cell_map(trian::TriangulationPortion{Dc,Dp,<:TriangulationPortion}) where {Dc,Dp}
-  get_face_to_cell_map(trian.oldtrian)
-end
-function get_face_to_cell_map(trian::TriangulationPortion{Dc,Dp,<:BoundaryTriangulation}) where {Dc,Dp}
-  get_face_to_cell_map(trian.oldtrian)
-end
-
-function restrict(f::AbstractArray,trian::TriangulationPortion)
-  if (is_portion_of_boundary_triangulation(trian))
-    compose_field_arrays(reindex(f,trian), reindex(get_face_to_cell_map(trian),trian.cell_to_oldcell))
-  else
-    reindex(f,trian)
-  end
-end
+# is_portion_of_boundary_triangulation(::TriangulationPortion{Dc,Dp,<:Triangulation}) where {Dc,Dp}=false
+# is_portion_of_boundary_triangulation(trian::TriangulationPortion{Dc,Dp,<:TriangulationPortion}) where {Dc,Dp}=
+#   is_portion_of_boundary_triangulation(trian.oldtrian)
+# is_portion_of_boundary_triangulation(::TriangulationPortion{Dc,Dp,<:BoundaryTriangulation}) where {Dc,Dp}=true
+#
+# function get_face_to_cell_map(::TriangulationPortion{Dc,Dp,<:Triangulation}) where {Dc,Dp}
+#   @assert false "You can only call get_face_to_cell_map with a TriangulationPortion of a BoundaryTriangulation"
+# end
+# function get_face_to_cell_map(trian::TriangulationPortion{Dc,Dp,<:TriangulationPortion}) where {Dc,Dp}
+#   get_face_to_cell_map(trian.oldtrian)
+# end
+# function get_face_to_cell_map(trian::TriangulationPortion{Dc,Dp,<:BoundaryTriangulation}) where {Dc,Dp}
+#   get_face_to_cell_map(trian.oldtrian)
+# end
+#
+# function restrict(f::AbstractArray,trian::TriangulationPortion)
+#   if (is_portion_of_boundary_triangulation(trian))
+#     compose_field_arrays(reindex(f,trian), reindex(get_face_to_cell_map(trian),trian.cell_to_oldcell))
+#   else
+#     reindex(f,trian)
+#   end
+# end
 
 function get_cell_id(trian::BoundaryTriangulation)
   get_face_to_cell(trian)

--- a/src/Geometry/TriangulationPortions.jl
+++ b/src/Geometry/TriangulationPortions.jl
@@ -48,6 +48,10 @@ end
 #  reindex(f,trian)
 #end
 
+function restrict(f::AbstractArray,trian::TriangulationPortion)
+  reindex(restrict(f,trian.oldtrian),trian)
+end
+
 function get_normal_vector(trian::TriangulationPortion)
   reindex(get_normal_vector(trian.oldtrian),trian.cell_to_oldcell)
 end

--- a/src/Geometry/TriangulationPortions.jl
+++ b/src/Geometry/TriangulationPortions.jl
@@ -44,9 +44,9 @@ function get_cell_id(trian::TriangulationPortion)
   reindex(get_cell_id(trian.oldtrian),trian.cell_to_oldcell)
 end
 
-function restrict(f::AbstractArray,trian::TriangulationPortion)
-  reindex(f,trian)
-end
+#function restrict(f::AbstractArray,trian::TriangulationPortion)
+#  reindex(f,trian)
+#end
 
 function get_normal_vector(trian::TriangulationPortion)
   reindex(get_normal_vector(trian.oldtrian),trian.cell_to_oldcell)

--- a/src/Geometry/TriangulationPortions.jl
+++ b/src/Geometry/TriangulationPortions.jl
@@ -44,12 +44,8 @@ function get_cell_id(trian::TriangulationPortion)
   reindex(get_cell_id(trian.oldtrian),trian.cell_to_oldcell)
 end
 
-#function restrict(f::AbstractArray,trian::TriangulationPortion)
-#  reindex(f,trian)
-#end
-
 function restrict(f::AbstractArray,trian::TriangulationPortion)
-  reindex(restrict(f,trian.oldtrian),trian)
+  reindex(restrict(f,trian.oldtrian),trian.cell_to_oldcell)
 end
 
 function get_normal_vector(trian::TriangulationPortion)

--- a/test/GeometryTests/TriangulationPortionsTests.jl
+++ b/test/GeometryTests/TriangulationPortionsTests.jl
@@ -30,6 +30,13 @@ test_triangulation(strian)
 ns = get_normal_vector(strian)
 @test length(ns) == num_cells(strian)
 
+v = [i for i=1:num_cells(trian)]
+cell_to_oldcell = [2,9,7]
+trian_portion = TriangulationPortion(oldtrian,cell_to_oldcell)
+trian_portion_portion = TriangulationPortion(trian_portion,[3,1])
+@test get_cell_id(trian_portion_portion)==[7,2]
+@test restrict(v, trian_portion_portion)==[7,2]
+
 #using Gridap.Visualization
 #writevtk(oldtrian,"oldtrian")
 #writevtk(btrian,"btrian",cellfields=["normal"=>nb],celldata=["oldcell"=>get_cell_id(btrian)])
@@ -37,4 +44,3 @@ ns = get_normal_vector(strian)
 #  celldata=["oldcell_left"=>get_cell_id(strian).left,"oldcell_right"=>get_cell_id(strian).right])
 
 end # module
-


### PR DESCRIPTION
Hi @fverdugo,

when working with `GridapDistributed.jl`, I figured out that the (current) implementation of `restrict(::AbstractArray,::TriangulationPortion)`, available [here](https://github.com/gridap/Gridap.jl/blob/v0.10.2/src/Geometry/TriangulationPortions.jl#L47) is wrong whenever it is fed up with a portion of a triangulation that extends `BoundaryTriangulation` (or a portion of a portion of `BoundaryTriangulation`, a portion of a portion of a portion of `BoundaryTriangulation`, etc.). The current patch fixes the implementation of `restrict` in such cases. It also immediately fixes `restrict(::AbstractArray,::TriangulationPortion)` for portions of `SkeletonTriangulation`s, as these rely on portions of `BoundaryTriangulation's`. I tested that this fix works with `GridapDistributed.jl`, but I did not find a way to extend the current tests in `Gridap.jl` in order to  test this feature. Any idea?

@amartinhuertas 






