### PR TITLE
Gradient scalar product

### DIFF
--- a/src/Fields/FieldOperations.jl
+++ b/src/Fields/FieldOperations.jl
@@ -134,7 +134,7 @@ end
 
 function kernel_testitem!(
   c,k::FieldBinOp,a::AbstractMatrix,b::AbstractVector)
-  if _valid_checks_matvec(a,b) 
+  if _valid_checks_matvec(a,b)
     apply_kernel!(c,k,a,b)
   else
     c.array
@@ -284,3 +284,18 @@ for op in (:+,:-)
   end
 end
 
+for op in (:*,:/)
+  @eval begin
+
+    function apply_kernel_gradient(k::FieldBinOp{typeof($op)},a::Number,b)
+      gb = field_gradient(b)
+      apply_kernel_to_field(k,a,gb)
+    end
+
+    function apply_gradient(k::Valued{FieldBinOp{typeof($op)}},a::Number,b)
+      gb = field_array_gradient(b)
+      apply(k,a,gb)
+    end
+
+  end
+end

--- a/test/FieldsTests/FieldOperationsTests.jl
+++ b/test/FieldsTests/FieldOperationsTests.jl
@@ -115,4 +115,10 @@ agx = fill(gx,l)
 ∇agx = fill(∇gx,l)
 test_array_of_fields(ag,ax,agx,grad=∇agx)
 
+g = field_operation(*,va,fa)
+gx = [*(va,ai) for ai in fax]
+∇gx = [*(va,ai) for ai in ∇fax]
+test_field(g,x,gx,grad=∇gx)
+
+
 end # module


### PR DESCRIPTION
Added the product (`*`) binary operation between a scalar and a field gradient. This feature enables to work with expressions of the following type:
```julia
uθ = θ*u + (1-θ)*un
integrate(ε(uθ),trian,quad)
```