### PR TITLE
Trigger ci x86 only on master and PRs on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         arch:
           - x64
           - x86
-    if: ${{ matrix.arch == x64 || github.base_ref == 'ref/head/master' || (github.event_name == 'pull_request' && github.base_ref == 'ref/head/master') }}
+    if: ${{ github.base_ref == 'ref/head/master' || (github.event_name == 'pull_request' && github.base_ref == 'ref/head/master') }}
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
           - ubuntu-latest
         arch:
           - x64
-          - x86
-    if: ${{ github.base_ref == 'ref/head/master' || (github.event_name == 'pull_request' && github.base_ref == 'ref/head/master') }}
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
@@ -37,6 +35,9 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           file: lcov.info
+
+        
+        
   drivers:
     name: Drivers ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 name: CI
-on:
-  - push
-  - pull_request
+on: [push, pull_request]
 jobs:
   test:
     name: Tests ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
@@ -16,6 +14,7 @@ jobs:
         arch:
           - x64
           - x86
+    if: ${{ matrix.arch == x64 || github.base_ref == 'ref/head/master' || (github.event_name == 'pull_request' && github.base_ref == 'ref/head/master') }}
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
@@ -38,7 +37,7 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           file: lcov.info
-  divers:
+  drivers:
     name: Drivers ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci_x86.yml
+++ b/.github/workflows/ci_x86.yml
@@ -37,7 +37,3 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
-        with:
-          file: lcov.info

--- a/.github/workflows/ci_x86.yml
+++ b/.github/workflows/ci_x86.yml
@@ -1,0 +1,43 @@
+name: CI_X86
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  test:
+    name: Tests ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.5'
+        os:
+          - ubuntu-latest
+        arch:
+          - x86 
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info

--- a/.github/workflows/ci_x86.yml
+++ b/.github/workflows/ci_x86.yml
@@ -2,10 +2,10 @@ name: CI_X86
 on: 
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 jobs:
   test:
     name: Tests ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}


### PR DESCRIPTION
"If" statement in GH actions does not support the matrix context: 

https://github.community/t/feature-request-and-use-case-example-to-allow-matrix-in-if-s/126067

It is a pitty as I could have used something like: 

```
if: ${{ matrix.arch == 'x86' || github.base_ref == 'ref/head/master' || (github.event_name == 'pull_request' && github.base_ref == 'ref/head/master') }}
```

Thus, I had to proceed the manual way ...
