### PR TITLE
Allow syntax `l(v)=0` for linear forms.

### DIFF
--- a/src/FESpaces/Assemblers.jl
+++ b/src/FESpaces/Assemblers.jl
@@ -324,3 +324,24 @@ function _pair_contribution_when_possible(biform,liform,uhd)
   matvec, mat, _vec
 end
 
+# allow linear forms like `l(v) = 0
+
+function collect_cell_vector(l::Number)
+  @notimplementedif l != 0
+  w = []
+  r = []
+  (w,r)
+end
+
+function collect_cell_matrix_and_vector(mat_contributions::DomainContribution,l::Number)
+  @notimplementedif l != 0
+  vec_contributions = DomainContribution()
+  collect_cell_matrix_and_vector(mat_contributions,vec_contributions)
+end
+
+function collect_cell_matrix_and_vector(
+  biform::DomainContribution,l::Number,uhd::FEFunction)
+  liform = DomainContribution()
+  collect_cell_matrix_and_vector(biform,liform,uhd)
+end
+

--- a/test/FESpacesTests/AssemblersTests.jl
+++ b/test/FESpacesTests/AssemblersTests.jl
@@ -88,4 +88,32 @@ Tb = get_vector_type(assem)
 @test eltype(Ta) == ComplexF64
 @test eltype(Tb) == ComplexF64
 
+# Now with an homogeneous linear form
+
+a(u,v) = ∫(∇(u)⋅∇(v))*dΩ + ∫(u*v)*dΓ
+ℓ(v) = 0
+
+mat_contribs = a(du,dv)
+vec_contribs = ℓ(dv)
+
+data = collect_cell_matrix(mat_contribs)
+A = assemble_matrix(assem,data)
+@test size(A) == (num_free_dofs(V), num_free_dofs(U))
+
+data = collect_cell_vector(vec_contribs)
+b = assemble_vector(assem,data)
+x = A\b
+@test x ≈ b
+
+data = collect_cell_matrix_and_vector(mat_contribs,vec_contribs)
+A,b = assemble_matrix_and_vector(assem,data)
+x = A\b
+@test x ≈ b
+
+uhd = zero(U)
+data = collect_cell_matrix_and_vector(mat_contribs,vec_contribs,uhd)
+A,b = assemble_matrix_and_vector(assem,data)
+x = A\b
+@test x ≈ b
+
 end # module


### PR DESCRIPTION
Addresses issue #473