### PR TITLE
Misc typos in documentation and code

### DIFF
--- a/src/Arrays/LazyArrays.jl
+++ b/src/Arrays/LazyArrays.jl
@@ -81,14 +81,14 @@ end
 
 """
 Subtype of `AbstractArray` which is the result of `lazy_map`. It represents the
-result of lazy_maping a `Map` to a set of arrays that
+result of lazy_mapping a `Map` to a set of arrays that
 contain the mapping arguments. This struct makes use of the cache provided
 by the mapping in order to compute its indices (thus allowing to prevent
 allocation). The array is lazy, i.e., the values are only computed on
 demand. It extends the `AbstractArray` API with two methods:
 
    `array_cache(a::AbstractArray)`
-   `getindex!(a::AbstractArray,i...)`
+   `getindex!(cache,a::AbstractArray,i...)`
 """
 struct LazyArray{G,T,N,F} <: AbstractArray{T,N}
   g::G
@@ -276,4 +276,3 @@ Base.IndexStyle(::Type{<:ArrayWithCounter{T,N,A}}) where {T,A,N} = IndexStyle(A)
 function resetcounter!(a::ArrayWithCounter)
   fill!(a.counter,zero(eltype(a.counter)))
 end
-

--- a/src/Arrays/Maps.jl
+++ b/src/Arrays/Maps.jl
@@ -49,7 +49,7 @@ per thread).
 
       Gridap.Arrays.evaluate!(cache,f,x...)
 
-  has not beed defined for the requested types (see stack trace).
+  has not been defined for the requested types (see stack trace).
   """
 end
 
@@ -129,7 +129,7 @@ function `f`.
 # Example
 
 ```jldoctest
-using Gridap.Maps
+using Gridap.Arrays
 
 a = [3,2]
 b = [2,1]

--- a/src/CellData/CellFields.jl
+++ b/src/CellData/CellFields.jl
@@ -24,8 +24,6 @@ function CellPoint(
   cell_phys_point::AbstractArray{<:Union{Point,AbstractArray{<:Point}}},
   trian::Triangulation,
   domain_style::PhysicalDomain)
-  cell_invmap = lazy_map(inverse_map,cell_map)
-
   cell_map = get_cell_map(trian)
   cell_invmap = lazy_map(inverse_map,cell_map)
   cell_ref_point = lazy_map(evaluate,cell_invmap,cell_phys_point)

--- a/src/CellData/CellQuadratures.jl
+++ b/src/CellData/CellQuadratures.jl
@@ -17,10 +17,10 @@ function CellQuadrature(trian::Triangulation,degree::Integer)
   ctype_to_reffe, cell_to_ctype = compress_cell_data(get_cell_reffe(trian))
   ctype_to_quad = map(r->Quadrature(get_polytope(r),degree),ctype_to_reffe)
   ctype_to_point = map(get_coordinates,ctype_to_quad)
-  ctype_to_weigth = map(get_weights,ctype_to_quad)
+  ctype_to_weight = map(get_weights,ctype_to_quad)
   cell_quad = expand_cell_data(ctype_to_quad,cell_to_ctype)
   cell_point = expand_cell_data(ctype_to_point,cell_to_ctype)
-  cell_weight = expand_cell_data(ctype_to_weigth,cell_to_ctype)
+  cell_weight = expand_cell_data(ctype_to_weight,cell_to_ctype)
   CellQuadrature(cell_quad,cell_point,cell_weight,trian,ReferenceDomain())
 end
 
@@ -137,4 +137,3 @@ function _meas_K_fill!(bgcell_to_dV,cell_to_dV,cell_to_bgcell)
     bgcell_to_dV[bgcell] += dV
   end
 end
-

--- a/src/Fields/FieldArrays.jl
+++ b/src/Fields/FieldArrays.jl
@@ -374,7 +374,7 @@ struct TransposeMap <: Map end
 """
 Given a matrix `np` x `nf1` x `nf2` result of the evaluation of a field vector
 on a vector of points, it returns an array in which the field axes (second and
-third axes) are permuted. It is equivalent as `Base.permutedims(A,(1,3,2)`
+third axes) are permuted. It is equivalent as `Base.permutedims(A,(1,3,2))`
 but more performant, since it does not involve allocations.
 """
 struct TransposeFieldIndices{A,T} <: AbstractArray{T,3}
@@ -509,4 +509,3 @@ for op in (:*,:⋅,:⊙,:⊗)
     end
   end
 end
-

--- a/src/Fields/FieldsInterfaces.jl
+++ b/src/Fields/FieldsInterfaces.jl
@@ -99,7 +99,7 @@ function gradient_type(::Type{T},x::Point) where T
 end
 
 """
-Type that represents the gradient of a field. The wrapped field implements must
+Type that represents the gradient of a field. The wrapped field must
 implement `evaluate_gradient!` and `return_gradient_cache` for this gradient
 to work.
 

--- a/src/Polynomials/MonomialBases.jl
+++ b/src/Polynomials/MonomialBases.jl
@@ -5,7 +5,7 @@ struct Monomial <: Field end
 
 Type representing a basis of multivariate scalar-valued, vector-valued, or
 tensor-valued, iso- or aniso-tropic monomials. The fields
-of this `struct` are not public
+of this `struct` are not public.
 This type fully implements the [`Field`](@ref) interface, with up to second order
 derivatives.
 """
@@ -28,7 +28,7 @@ end
 
 This version of the constructor allows to pass a tuple `orders` containing the
 polynomial order to be used in each of the `D` dimensions in order to  construct
-and anisotropic tensor-product space.
+an anisotropic tensor-product space.
 """
 function MonomialBasis{D}(
   ::Type{T}, orders::NTuple{D,Int}, filter::Function=_q_filter) where {D,T}


### PR DESCRIPTION
Hi @fverdugo ... just an (incomplete) set of typos that I found in the documentation and code while navigating through the kernel refactorization.