### PR TITLE
SymTensorValueTypes: Use integer division

### DIFF
--- a/src/TensorValues/SymFourthOrderTensorValueTypes.jl
+++ b/src/TensorValues/SymFourthOrderTensorValueTypes.jl
@@ -8,7 +8,7 @@ Type representing a symmetric fourth-order tensor
 struct SymFourthOrderTensorValue{D,T,L} <: MultiValue{Tuple{D,D,D,D},T,4,L}
   data::NTuple{L,T}
   function SymFourthOrderTensorValue{D,T}(data::NTuple{L,T}) where {D,T,L}
-    @assert L == (D*(D+1)/2)^2
+    @assert L == (D*(D+1)÷2)^2
     new{D,T,L}(data)
   end
 end
@@ -71,7 +71,7 @@ convert(::Type{<:SymFourthOrderTensorValue{D,T}}, arg::SymFourthOrderTensorValue
 ###############################################################
 
 @generated function zero(::Type{<:SymFourthOrderTensorValue{D,T}}) where {D,T}
-  L=Int((D*(D+1)/2)^2)
+  L=Int((D*(D+1)÷2)^2)
   quote
     SymFourthOrderTensorValue{D,T}(tfill(zero(T),Val{$L}()))
   end

--- a/src/TensorValues/SymFourthOrderTensorValueTypes.jl
+++ b/src/TensorValues/SymFourthOrderTensorValueTypes.jl
@@ -71,7 +71,7 @@ convert(::Type{<:SymFourthOrderTensorValue{D,T}}, arg::SymFourthOrderTensorValue
 ###############################################################
 
 @generated function zero(::Type{<:SymFourthOrderTensorValue{D,T}}) where {D,T}
-  L=Int((D*(D+1)÷2)^2)
+  L=(D*(D+1)÷2)^2
   quote
     SymFourthOrderTensorValue{D,T}(tfill(zero(T),Val{$L}()))
   end

--- a/src/TensorValues/SymTensorValueTypes.jl
+++ b/src/TensorValues/SymTensorValueTypes.jl
@@ -105,7 +105,7 @@ convert(::Type{<:SymTensorValue{D,T}}, arg::SymTensorValue{D,T}) where {D,T} = a
 ###############################################################
 
 @generated function zero(::Type{<:SymTensorValue{D,T}}) where {D,T}
-  L=Int(D*(D+1)÷2)
+  L=D*(D+1)÷2
   quote
     SymTensorValue{D,T}(tfill(zero(T),Val{$L}()))
   end

--- a/src/TensorValues/SymTensorValueTypes.jl
+++ b/src/TensorValues/SymTensorValueTypes.jl
@@ -8,7 +8,7 @@ Type representing a symmetric second-order tensor
 struct SymTensorValue{D,T,L} <: MultiValue{Tuple{D,D},T,2,L}
     data::NTuple{L,T}
     function SymTensorValue{D,T}(data::NTuple{L,T}) where {D,T,L}
-        @assert L == D*(D+1)/2
+        @assert L == D*(D+1)÷2
         new{D,T,L}(data)
     end
 end
@@ -105,7 +105,7 @@ convert(::Type{<:SymTensorValue{D,T}}, arg::SymTensorValue{D,T}) where {D,T} = a
 ###############################################################
 
 @generated function zero(::Type{<:SymTensorValue{D,T}}) where {D,T}
-  L=Int(D*(D+1)/2)
+  L=Int(D*(D+1)÷2)
   quote
     SymTensorValue{D,T}(tfill(zero(T),Val{$L}()))
   end


### PR DESCRIPTION
Use integer division to calculate number of elements