### PR TITLE
Default implementation of compress(cell_mat,trian)

### DIFF
--- a/src/FESpaces/Assemblers.jl
+++ b/src/FESpaces/Assemblers.jl
@@ -239,8 +239,9 @@ function collect_cell_matrix(a::DomainContribution)
   for trian in get_domains(a)
     cell_mat = get_contribution(a,trian)
     @assert eltype(cell_mat) <: AbstractMatrix
-    push!(w,cell_mat)
-    push!(r,get_cell_to_bgcell(trian))
+    ccell_mat, ccell_bgcell = compress(cell_mat,trian)
+    push!(w,ccell_mat)
+    push!(r,ccell_bgcell)
   end
   (w,r,r)
 end
@@ -261,10 +262,11 @@ function _collect_cell_matvec(a::DomainContribution)
   w = []
   r = []
   for trian in get_domains(a)
-    cell_mat = get_contribution(a,trian)
-    @assert eltype(cell_mat) <: Tuple
-    push!(w,cell_mat)
-    push!(r,get_cell_to_bgcell(trian))
+    cell_matvec = get_contribution(a,trian)
+    @assert eltype(cell_matvec) <: Tuple
+    ccell_matvec, ccell_bgcell = compress(cell_matvec,trian)
+    push!(w,ccell_matvec)
+    push!(r,ccell_bgcell)
   end
   (w,r,r)
 end

--- a/src/Geometry/Geometry.jl
+++ b/src/Geometry/Geometry.jl
@@ -95,6 +95,7 @@ export is_oriented
 export is_regular
 export expand_cell_data
 export compress_cell_data
+export compress
 
 export UnstructuredGridTopology
 

--- a/src/Geometry/Triangulations.jl
+++ b/src/Geometry/Triangulations.jl
@@ -305,6 +305,10 @@ function get_cell_node_ids(trian::Triangulation)
   @notimplemented
 end
 
+function compress(cell_mat,trian::Triangulation)
+  cell_mat, get_cell_to_bgcell(trian)
+end
+
 #"""
 #"""
 #function CellField(object,trian::Triangulation)


### PR DESCRIPTION
Default dummy implementation of `compress() ` which will allow to compress the cell matrices before the assembling. Thus, reduce the memory consumption when multiple cell matrices point to the same cell, e.g., GridapEmbedded.