### PR TITLE
Add norm operation for TensorValues

### DIFF
--- a/src/TensorValues/Operations.jl
+++ b/src/TensorValues/Operations.jl
@@ -497,6 +497,7 @@ function meas(v::MultiValue{Tuple{2,3}})
 end
 
 @inline norm(u::MultiValue{Tuple{D}}) where D = sqrt(inner(u,u))
+@inline norm(u::MultiValue{Tuple{D1,D2}}) where {D1,D2} = sqrt(inner(u,u))
 @inline norm(u::MultiValue{Tuple{0},T}) where T = sqrt(zero(T))
 
 ###############################################################

--- a/test/TensorValuesTests/OperationsTests.jl
+++ b/test/TensorValuesTests/OperationsTests.jl
@@ -432,6 +432,9 @@ v = VectorValue(2.0,3.0)
 @test dot(u,v) ≈ inner(u,v)
 @test norm(u) ≈ sqrt(inner(u,u))
 
+a = TensorValue(1,2,3,4)
+@test norm(a) ≈ sqrt(inner(a,a))
+
 a = VectorValue(1.0,2.0)
 b = VectorValue(2.0,3.0)
 @test [a,b] ≈ [a,b]


### PR DESCRIPTION
In the p-Laplacian tutorial you can use norm∘∇(u). If you try to do the same: norm∘T where T belongs to a Tensor Valued Space (like, TestFESpace(model,ReferenceFE(lagrangian,TensorValue{2,2,Float64,4},order),conformity=:L2)), it doesn`t work. Adding the method: norm(u::MultiValue{Tuple{D1,D2}}) where {D1,D2} = sqrt(inner(u,u)) in TensorValues/Operations.jl seems to solve the issue.