### PR TITLE
Solved an ambiguity in the declaration of propertynames for FEFunctions

### DIFF
--- a/src/CellData/CellFields.jl
+++ b/src/CellData/CellFields.jl
@@ -529,7 +529,7 @@ function Base.getproperty(x::CellField, sym::Symbol)
   end
 end
 
-function Base.propertynames(x::CellField, private=false)
+function Base.propertynames(x::CellField, private::Bool=false)
   (fieldnames(typeof(x))...,:⁺,:plus,:⁻,:minus)
 end
 

--- a/src/FESpaces/ConformingFESpaces.jl
+++ b/src/FESpaces/ConformingFESpaces.jl
@@ -21,7 +21,7 @@ function Base.getproperty(a::CellConformity, sym::Symbol)
   end
 end
 
-function Base.propertynames(x::CellConformity, private=false)
+function Base.propertynames(x::CellConformity, private::Bool=false)
   (fieldnames(typeof(x))...,:d_ctype_offset,:d_ctype_ldface_own_ldofs)
 end
 
@@ -60,10 +60,10 @@ struct CellFE{T} <: GridapType
   cell_dof_basis::AbstractArray{<:AbstractVector{<:Dof}}
   cell_shapefuns_domain::DomainStyle
   cell_dof_basis_domain::DomainStyle
-  max_order::Int 
+  max_order::Int
 end
 # If the shapefuns are not polynomials, max_order has to be understood as the order of a
-# reasonable quadrature rule to integrate the shape functions. Only used by FESpace 
+# reasonable quadrature rule to integrate the shape functions. Only used by FESpace
 # constructors that need to integrate the shape functions (e.g., ZeroMeanFESpace).
 
 Geometry.num_cells(cell_fe::CellFE) = length(cell_fe.cell_ctype)

--- a/src/Geometry/SkeletonTriangulations.jl
+++ b/src/Geometry/SkeletonTriangulations.jl
@@ -26,7 +26,7 @@ function Base.getproperty(x::SkeletonTriangulation, sym::Symbol)
   end
 end
 
-function Base.propertynames(x::SkeletonTriangulation, private=false)
+function Base.propertynames(x::SkeletonTriangulation, private::Bool=false)
   (fieldnames(typeof(x))...,:⁺,:⁻)
 end
 

--- a/src/Geometry/Triangulations.jl
+++ b/src/Geometry/Triangulations.jl
@@ -204,7 +204,7 @@ function Base.getproperty(x::SkeletonPair, sym::Symbol)
   end
 end
 
-function Base.propertynames(x::SkeletonPair, private=false)
+function Base.propertynames(x::SkeletonPair, private::Bool=false)
   (fieldnames(typeof(x))...,:⁺,:⁻)
 end
 


### PR DESCRIPTION
The following script reproduces the error in the call to `propertynames` that this PR fixes. I found the error accidentally while doing some other stuff. 

```
using Test
using Gridap.Geometry
using Gridap.ReferenceFEs
using Gridap.FESpaces
using Gridap.CellData
using Gridap.TensorValues
using Gridap.Fields
using Gridap.Io


order = 0

reffe = ReferenceFE(TRI,raviart_thomas,order)

domain =(0,1,0,1)
partition = (1,1)
model = simplexify(CartesianDiscreteModel(domain,partition))

V = FESpace(model,reffe,conformity=DivConformity())

v(x) = VectorValue(-0.5*x[1]+1.0,-0.5*x[2])
vh = interpolate(v,V)
propertynames(vh)
```

The error is as follows:

```
julia> propertynames(vh)
ERROR: MethodError: propertynames(::SingleFieldFEFunction{GenericCellField{ReferenceDomain}}, ::Bool) is ambiguous. Candidates:
  propertynames(x, private::Bool) in Base at reflection.jl:1581
  propertynames(x::CellField, private) in Gridap.CellData at /home/amartin/git-repos/Gridap.jl/src/CellData/CellFields.jl:532
Possible fix, define
  propertynames(::CellField, ::Bool)
Stacktrace:
 [1] propertynames(x::SingleFieldFEFunction{GenericCellField{ReferenceDomain}})
   @ Gridap.CellData ~/git-repos/Gridap.jl/src/CellData/CellFields.jl:533
 [2] top-level scope
   @ REPL[17]:1
```


