### PR TITLE
Allowing to reuse caches when inserting elemental matrices and vectors to global arrays

### DIFF
--- a/src/Arrays/AlgebraMaps.jl
+++ b/src/Arrays/AlgebraMaps.jl
@@ -38,3 +38,30 @@ end
   mul!(d,a,b,k.α,k.β)
   d
 end
+
+struct AddEntriesMap{F} <: Map
+  combine::F
+end
+
+function evaluate!(cache,k::AddEntriesMap,A,v,i,j)
+  add_entries!(k.combine,A,v,i,j)
+end
+
+function evaluate!(cache,k::AddEntriesMap,A,v,i)
+  add_entries!(k.combine,A,v,i)
+end
+
+struct TouchEntriesMap <: Map end
+
+function evaluate!(cache,k::TouchEntriesMap,A,v,i,j)
+  add_entries!(+,A,nothing,i,j)
+end
+
+function evaluate!(cache,k::TouchEntriesMap,A,v,i)
+  add_entries!(+,A,nothing,i)
+end
+
+
+
+
+

--- a/src/Arrays/Arrays.jl
+++ b/src/Arrays/Arrays.jl
@@ -127,6 +127,9 @@ export similar_tree_node
 import Gridap.Io: to_dict
 import Gridap.Io: from_dict
 
+export AddEntriesMap
+export TouchEntriesMap
+
 export ∑
 
 include("Interface.jl")

--- a/test/ArraysTests/AlgebraMapsTests.jl
+++ b/test/ArraysTests/AlgebraMapsTests.jl
@@ -25,4 +25,25 @@ b = 4
 c = a*b
 test_map(c,*,a,b)
 
+k! = AddEntriesMap(+)
+
+A = zeros(4,5)
+k!(A,fill(3.0,2,2),[1,3],[2,1])
+k!(A,fill(3.0,2,2),[1,3],[2,1])
+@test A[[1,3],[2,1]] == fill(6.0,2,2)
+
+A = zeros(4)
+k!(A,fill(3.0,2),[1,3])
+k!(A,fill(3.0,2),[1,3])
+@test A[[1,3]] == fill(6.0,2)
+
+k! = TouchEntriesMap()
+A = zeros(4,5)
+k!(A,fill(3.0,2,2),[1,1],[2,1])
+@test A == zeros(4,5)
+
+A = zeros(4)
+k!(A,fill(3.0,2),[1,1])
+@test A == zeros(4)
+
 end # module

--- a/test/FieldsTests/ArrayBlocksTests.jl
+++ b/test/FieldsTests/ArrayBlocksTests.jl
@@ -208,6 +208,25 @@ A11t = transpose(A11)
 @test A11*A11t != nothing
 @test A*transpose(A) != nothing
 
+I11 = ArrayBlock([[1,2,2,1],[3,1,6,2]],[true,true])
+J11 = ArrayBlock([[3,2,1,5],[6,1,3,4]],[true,true])
+I = ArrayBlock([I11,I11],[true,true])
+J = ArrayBlock([J11,J11],[true,true])
+c11 = c[1,1]
+
+mat = zeros(ComplexF64,6,6)
+vec = zeros(ComplexF64,6)
+k! = AddEntriesMap(+)
+k!(mat,A11,I11,J11)
+k!(vec,c11,I11)
+k!(mat,A,I,J)
+k!(vec,c,I)
+k! = TouchEntriesMap()
+k!(mat,A11,I11,J11)
+k!(vec,c11,I11)
+k!(mat,A,I,J)
+k!(vec,c,I)
+
 #display(A)
 #display(c)
 #display(A[1,1])


### PR DESCRIPTION
Needed e.g., for Petsc since it uses 0-based indices and we need a place to store the conversion.