### PR TITLE
Adding DensifyInnerMostBlockLevelMap

### DIFF
--- a/src/Fields/DensifyInnerMostBlockLevelMaps.jl
+++ b/src/Fields/DensifyInnerMostBlockLevelMaps.jl
@@ -1,0 +1,325 @@
+struct DensifyInnerMostBlockLevelMap <: Map
+end
+
+function return_cache(k::DensifyInnerMostBlockLevelMap,
+                      a::VectorBlock{<:Vector{T}}) where {T}
+  @check all(a.touched)
+  # Precompute the size of each row block.
+  # We are assuming that the size of each row
+  # block is going to be equivalent for all cells
+  s=0
+  brs=Vector{Int}(undef,size(a)[1])
+  for i=1:size(a)[1]
+    s=s+length(a.array[i])
+    brs[i]=length(a.array[i])
+  end
+  CachedArray(Vector{T}(undef,(s,))),brs
+end
+
+function return_cache(k   :: DensifyInnerMostBlockLevelMap,
+                      brs :: Vector{<:Integer},
+                      a   :: VectorBlock{<:Vector{T}}) where {T}
+  @check length(brs)==size(a)[1]
+  CachedArray(Vector{T}(undef,(sum(brs),)))
+end
+
+
+function return_cache(k::DensifyInnerMostBlockLevelMap,
+                      a::MatrixBlock{<:Vector{T}}) where {T}
+  @check _check_preconditions(k,a)
+  s=Vector{Int}(undef,2)
+  s[1]=0
+  s[2]=size(a)[2]
+  # Precompute the size of each row block.
+  # We are assuming that the size of each row
+  # block is going to be equivalent for all cells
+  brs=Vector{Int}(undef,size(a)[1])
+  for i=1:size(a)[1]
+    for j=1:size(a)[2]
+      if (a.touched[i,j])
+        s[1]=s[1]+length(a.array[i,j])
+        brs[i]=length(a.array[i,j])
+        break
+      end
+    end
+  end
+  CachedArray(Array{T,2}(undef,Tuple(s))),brs
+end
+
+function return_cache(k   :: DensifyInnerMostBlockLevelMap,
+                      brs :: Vector{<:Integer},
+                      a   :: MatrixBlock{<:Vector{T}}) where {T}
+  @check length(brs)==size(a)[1]
+  CachedArray(Array{T,2}(undef,(sum(brs),size(a)[2])))
+end
+
+function _check_preconditions(k::DensifyInnerMostBlockLevelMap,
+                              a::MatrixBlock{<:Vector{T}}) where {T}
+  # Double check that, for each row, there is at least one non-zero block
+  found=false
+  for i=1:size(a)[1]
+    found=false
+    for j=1:size(a)[2]
+      if (a.touched[i,j])
+        found = true
+        break
+      end
+    end
+    if !found
+      break
+    end
+  end
+  found
+end
+
+function return_cache(k::DensifyInnerMostBlockLevelMap,
+                      a::VectorBlock{<:Matrix{T}}) where {T}
+  @check all(a.touched)
+  s=Vector{Int}(undef,2)
+  s[1]=0
+  s[2]=size(a.array[1])[2]
+  for i=1:size(a)[1]
+    s[1]=s[1]+size(a.array[i])[1]
+  end
+  CachedArray(Array{T,2}(undef,Tuple(s)))
+end
+
+function return_cache(k  ::DensifyInnerMostBlockLevelMap,
+                      brs::Vector{<:Integer},
+                      cs ::Integer,
+                      a  ::VectorBlock{<:Matrix{T}}) where {T}
+  CachedArray(Array{T,2}(undef,(sum(brs),cs)))
+end
+
+
+function return_cache(k::DensifyInnerMostBlockLevelMap,
+                      a::MatrixBlock{<:Matrix{T}}) where {T}
+  @check _check_preconditions(k,a)
+  s=Vector{Int}(undef,2)
+  s[1]=0
+  s[2]=0
+  # Precompute the size of each row/col block.
+  # We are assuming that the size of each row/col
+  # block is going to be equivalent for all cells
+  brs=Vector{Int}(undef,size(a)[1])
+  bcs=Vector{Int}(undef,size(a)[2])
+  # Row traversal
+  for i=1:size(a)[1]
+    for j=1:size(a)[2]
+      if (a.touched[i,j])
+        s[1]=s[1]+size(a.array[i,j])[1]
+        brs[i]=size(a.array[i,j])[1]
+        break
+      end
+    end
+  end
+  #Column traversal
+  for j=1:size(a)[2]
+     for i=1:size(a)[1]
+       if (a.touched[i,j])
+        s[2]=s[2]+size(a.array[i,j])[2]
+        bcs[j]=size(a.array[i,j])[2]
+        break
+       end
+     end
+  end
+  CachedArray(Array{T,2}(undef,Tuple(s))),brs,bcs
+end
+
+function _check_preconditions(k::DensifyInnerMostBlockLevelMap,
+                              a::MatrixBlock{<:Matrix{T}}) where {T}
+  # Double check that, for each row,
+  # there is at least one non-zero block
+  found=false
+  for i=1:size(a)[1]
+    found=false
+    for j=1:size(a)[2]
+      if (a.touched[i,j])
+        found = true
+        break
+      end
+    end
+    if !found
+      break
+    end
+  end
+  # Double check that, for each col,
+  # there is at least one non-zero block
+  if (found)
+    for j=1:size(a)[2]
+      found=false
+      for i=1:size(a)[1]
+        if (a.touched[i,j])
+          found = true
+          break
+        end
+      end
+      if !found
+        break
+      end
+    end
+  end
+  found
+end
+
+function return_cache(k::DensifyInnerMostBlockLevelMap,
+                      brs::Vector{<:Integer},
+                      bcs::Vector{<:Integer},
+                      a::MatrixBlock{<:Matrix{T}}) where {T}
+  CachedArray(Array{T,2}(undef,(sum(brs),sum(bcs))))
+end
+
+
+function evaluate!(cache,
+                   k::DensifyInnerMostBlockLevelMap,
+                   a::VectorBlock{<:Vector{T}}) where {T}
+  cache_array, brs = cache
+  _evaluate!(cache_array,brs,a)
+end
+
+function evaluate!(cache,
+                   k   :: DensifyInnerMostBlockLevelMap,
+                   brs :: Vector{<:Integer},
+                   a   :: VectorBlock{<:Vector{T}}) where {T}
+  _evaluate!(cache,brs,a)
+end
+
+function _evaluate!(cache,
+                    brs::Vector{<:Integer},
+                    a::VectorBlock{<:Vector{T}}) where {T}
+  output  = cache.array
+  output .= zero(eltype(output))
+  current_i=1
+  for i=1:size(a)[1]
+    range = current_i:current_i+brs[i]-1
+    if (a.touched[i])
+      output[range] = a.array[i]
+    end
+    current_i = current_i + length(range)
+  end
+  output
+end
+
+function evaluate!(cache,
+                   k::DensifyInnerMostBlockLevelMap,
+                   a::MatrixBlock{<:Vector{T}}) where {T}
+  cache_array, brs = cache
+  _evaluate!(cache_array,brs,a)
+end
+
+function evaluate!(cache,
+                   k   :: DensifyInnerMostBlockLevelMap,
+                   brs :: Vector{<:Integer},
+                   a   :: MatrixBlock{<:Vector{T}}) where {T}
+  _evaluate!(cache,brs,a)
+end
+
+function _evaluate!(cache,
+                    brs::Vector{<:Integer},
+                    a::MatrixBlock{<:Vector{T}}) where {T}
+  output  = cache.array
+  output .= zero(eltype(output))
+  for j=1:size(a)[2]
+     current_i=1
+     for i=1:size(a)[1]
+        range = current_i:current_i+brs[i]-1
+        if (a.touched[i,j])
+          output[range,j] = a.array[i,j]
+        end
+        current_i = current_i + length(range)
+     end
+  end
+  output
+end
+
+function evaluate!(cache,
+                   k::DensifyInnerMostBlockLevelMap,
+                   a::MatrixBlock{<:Matrix{T}}) where {T}
+  cache_array, brs, bcs = cache
+  _evaluate!(cache_array, brs, bcs,a)
+end
+
+function evaluate!(cache,
+  k::DensifyInnerMostBlockLevelMap,
+  brs::Vector{<:Integer},
+  bcs::Vector{<:Integer},
+  a::MatrixBlock{<:Matrix{T}}) where {T}
+  _evaluate!(cache, brs, bcs, a)
+end
+
+function _evaluate!(cache_array, brs, bcs, a)
+  output  = cache_array.array
+  output .= zero(eltype(output))
+  current_j=1
+  for j=1:size(a)[2]
+    current_i=1
+    range_j = current_j:current_j+bcs[j]-1
+    for i=1:size(a)[1]
+      range_i = current_i:current_i+brs[i]-1
+      if (a.touched[i,j])
+         output[range_i,range_j] = a.array[i,j]
+      end
+      current_i = current_i + brs[i]
+    end
+    current_j = current_j + bcs[j]
+  end
+  output
+end
+
+function evaluate!(cache,
+                   k::DensifyInnerMostBlockLevelMap,
+                   a::VectorBlock{<:Matrix{T}}) where {T}
+  @check all(a.touched)
+  output = cache.array
+  current_i=1
+  n=size(a.array[1])[2]
+  for i=1:size(a)[1]
+    range=current_i:current_i+size(a.array[i])[1]-1
+    output[range,1:n] = a.array[i]
+    current_i=current_i+length(range)
+  end
+  output
+end
+
+function return_cache(k::DensifyInnerMostBlockLevelMap,
+      a::ArrayBlock{<:ArrayBlock{T,M} where {T,M},N}) where {N}
+    cache_touched=a.touched
+    i=findfirst(isone, cache_touched)
+    cache_block=return_cache(k,a.array[i])
+    cache_array=Array{typeof(cache_block),N}(undef,size(a))
+    output_array=Array{return_type(k,a.array[i]),N}(undef,size(a))
+    linds=LinearIndices(size(a))
+    cinds=CartesianIndices(size(a))
+    while i != nothing
+      cache_array[i]=cache_block
+      if (linds[i]+1 <= length(linds))
+        i=findnext(isone, cache_touched, cinds[linds[i]+1])
+        if (i!=nothing)
+          cache_block=return_cache(k,a.array[i])
+        end
+      else
+        i=nothing
+      end
+    end
+    ArrayBlock(cache_array,cache_touched),
+    ArrayBlock(output_array,cache_touched),
+    linds,
+    cinds
+end
+
+function evaluate!(cache,
+    k::DensifyInnerMostBlockLevelMap,
+    a::ArrayBlock{<:ArrayBlock{T,M} where {T,M},N}) where {N}
+    cache_array, output_array, linds, cinds = cache
+    @check cache_array.touched == a.touched
+    i=findfirst(isone, cache_array.touched)
+    while i != nothing
+      output_array.array[i]=evaluate!(cache_array.array[i],k,a.array[i])
+      if (linds[i]+1 <= length(linds))
+        i=findnext(isone, cache_array.touched, cinds[linds[i]+1])
+      else
+        i=nothing
+      end
+    end
+    output_array
+end

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -93,6 +93,8 @@ export VoidFieldMap
 export VoidBasis
 export VoidBasisMap
 
+export DensifyInnerMostBlockLevelMap
+
 include("FieldsInterfaces.jl")
 
 include("FieldArrays.jl")
@@ -110,5 +112,7 @@ include("AutoDiff.jl")
 include("ArrayBlocks.jl")
 
 include("InverseFields.jl")
+
+include("DensifyInnerMostBlockLevelMaps.jl")
 
 end

--- a/test/FieldsTests/DensifyInnerMostBlockLevelMapsTests.jl
+++ b/test/FieldsTests/DensifyInnerMostBlockLevelMapsTests.jl
@@ -1,0 +1,83 @@
+module DensifyInnerMostBlockLevelMapsTests
+   using Test
+   using Gridap
+   using Gridap.Fields
+   using Gridap.Arrays
+
+   m=DensifyInnerMostBlockLevelMap()
+
+   # VectorBlock{Vector} test
+   y=Vector{Vector{Float64}}(undef,3)
+   touched=Vector{Bool}(undef,3)
+   touched .= true
+   x=rand(3)
+   y[1]=x
+   y[2]=x.+1
+   y[3]=x.+2
+   by=ArrayBlock(y,touched)
+   cache=return_cache(m,by)
+   @test vcat(y...)==evaluate!(cache,m,by)
+
+   # MatrixBlock{Vector} test
+   x=rand(3)
+   y=Array{Vector{Float64},2}(undef,(1,4))
+   y[1,1]=x
+   y[1,3]=x.+2
+   y[1,4]=x.+3
+   touched  = Array{Bool,2}(undef,(1,4))
+   touched .= true
+   touched[1,2]=false
+   by=ArrayBlock(y,touched)
+   cache=return_cache(m,by)
+   @test hcat(y[1,1],zeros(3),y[1,3],y[1,4]) == evaluate!(cache,m,by)
+
+   # VectorBlock{Matrix} test
+   x=rand(1,3)
+   y=Array{Matrix{Float64}}(undef,(4,))
+   y[1]=x
+   y[2]=x.+1
+   y[3]=x.+2
+   y[4]=x.+3
+   touched  = Array{Bool,1}(undef,(4,))
+   touched .= true
+   by=ArrayBlock(y,touched)
+   cache=return_cache(m,by)
+   @test vcat(y...)==evaluate!(cache,m,by)
+
+   # MatrixBlock{Matrix} test
+   x1=rand(2,3)
+   x2=rand(3,3)
+   x3=rand(4,3)
+   y=Array{Matrix{Float64}}(undef,(3,3))
+   y[1,1]=x
+   y[2,1]=x2
+   y[3,1]=x3
+   y[1,2]=x.+3
+   y[1,3]=x.+5
+   touched  = Array{Bool,2}(undef,(3,3))
+   touched .= true
+   touched[2:3,2:3].=false
+   by=ArrayBlock(y,touched)
+   cache=return_cache(m,ArrayBlock(y,touched))
+   @test vcat(hcat(y[1,1:3]...),
+              hcat(y[2,1],zeros(3,3),zeros(3,3)),
+              hcat(y[3,1],zeros(4,3),zeros(4,3)))==evaluate!(cache,m,by)
+
+   # Nested blocking test
+   touched_parent      = Array{Bool,2}(undef,(3,3))
+   touched_parent     .= false
+   touched_parent[2,3] = true
+   y_parent            = Array{ArrayBlock{Matrix{Float64}},2}(undef,(3,3))
+   y_parent[2,3]       = by
+   parent              = ArrayBlock(y_parent,touched_parent)
+   cache=return_cache(m,parent)
+
+   result_touched  = Array{Bool,2}(undef,(3,3))
+   result_array    = Array{Matrix{Float64}}(undef,(3,3))
+   result_touched .= touched_parent
+   result_array[2,3] = vcat(hcat(y[1,1:3]...),
+                            hcat(y[2,1],zeros(3,3),zeros(3,3)),
+                            hcat(y[3,1],zeros(4,3),zeros(4,3)))
+
+   @test result_array[2,3] == evaluate!(cache,m,parent).array[2,3]
+end

--- a/test/FieldsTests/runtests.jl
+++ b/test/FieldsTests/runtests.jl
@@ -20,4 +20,6 @@ using Test
 
 @testset "InverseFields" begin include("InverseFieldsTests.jl") end
 
+@testset "DensifyInnerMostBlockLevelMapsTests" begin include("DensifyInnerMostBlockLevelMapsTests.jl") end
+
 end


### PR DESCRIPTION
Related to https://github.com/gridap/Gridap.jl/issues/584#issuecomment-924960194

Hi @fverdugo, 

find a first approach to isolating the code at hand. Concerns: 

1. Should the new `Map` actually go to the `Fields` namespace ?
2. The current `Map` is more general than it may actually be required to solve the issue of AD with multiple fields. In particular, it transforms into standard Julia arrays the innermost block in a hierarchical block structure. When such structure has a single level, then it reduces to what we need. 
3. Related to 2. Is the name appropriate? 

I would prefer to leave the current functionality as far as possible. This is what we need for our approach to hybrizable methods.