### PR TITLE
Fixed typo in LinearSolvers.jl

### DIFF
--- a/src/Algebra/LinearSolvers.jl
+++ b/src/Algebra/LinearSolvers.jl
@@ -194,7 +194,7 @@ function solve!(x::AbstractVector,
   ns = cache.ns
   residual!(b, op, x)
   numerical_setup!(ns,A)
-  ruml!(b,-1)
+  rmul!(b,-1)
   solve!(x,ns,b)
   cache
 end

--- a/test/AlgebraTests/LinearSolversTests.jl
+++ b/test/AlgebraTests/LinearSolversTests.jl
@@ -2,6 +2,7 @@ module LinearSolversTests
 
 using Test
 using Gridap.Algebra
+using Gridap.Algebra: NonlinearOperatorMock
 
 using LinearAlgebra
 using SparseArrays
@@ -79,5 +80,15 @@ cache = solve!(x0,ls,op2,cache,false)
 @test all(2*x .≈ x0)
 cache = solve!(x0,ls,op2,nothing,false)
 @test all(2*x .≈ x0)
+
+nlop = NonlinearOperatorMock()
+x = [1.0, 3.0]
+b = [0.0,0.0]
+A = [-1.0 0.0; 0.0 1.0]
+test_nonlinear_operator(nlop,x,b,jac=A)
+x0 = copy(x)
+nl_cache = solve!(x0,ls,nlop,nothing)
+nl_cache = solve!(x0,ls,nlop,nl_cache)
+
 
 end # module


### PR DESCRIPTION
Hi @fverdugo @amartinhuertas, 

I found a typo in `LinearSolvers.jl` when trying to update GridapODEs. Apparently the function `solve!` in line https://github.com/gridap/Gridap.jl/blob/2015bd1adfc12c37939f605e33cc5266403011e5/src/Algebra/LinearSolvers.jl#L187 was not stressed by any Gridap test. I added the corresponding test in `LinearSolversTests.jl`