### PR TITLE
export data_index

### DIFF
--- a/src/TensorValues/TensorValues.jl
+++ b/src/TensorValues/TensorValues.jl
@@ -58,6 +58,7 @@ export ⊗
 export ⋅¹
 export ⋅²
 export double_contraction
+export data_index
 
 import Base: show
 import Base: zero, one


### PR DESCRIPTION
Exporting `data_index` to ease the definition of tensors (relevant for symmetric tensors) from user drivers. 