### PR TITLE
CellFE constructor now gets optional arguments and pass them down

### DIFF
--- a/src/FESpaces/ConformingFESpaces.jl
+++ b/src/FESpaces/ConformingFESpaces.jl
@@ -94,14 +94,15 @@ Generate a CellFE from a vector of reference fes
 function CellFE(
   model::DiscreteModel,
   cell_reffe::AbstractArray{<:ReferenceFE},
-  conformity::Conformity
+  conformity::Conformity,
+  cell_fe_args...
  )
   cell_conformity = CellConformity(cell_reffe,conformity)
   ctype_reffe, cell_ctype = compress_cell_data(cell_reffe)
   ctype_num_dofs = map(num_dofs,ctype_reffe)
   ctype_ldof_comp = map(reffe->get_dof_to_comp(reffe),ctype_reffe)
-  cell_shapefuns = get_cell_shapefuns(model,cell_reffe,conformity)
-  cell_dof_basis = get_cell_dof_basis(model,cell_reffe,conformity)
+  cell_shapefuns = get_cell_shapefuns(model,cell_reffe,conformity,cell_fe_args...)
+  cell_dof_basis = get_cell_dof_basis(model,cell_reffe,conformity,cell_fe_args...)
   cell_shapefuns_domain = ReferenceDomain()
   cell_dof_basis_domain = cell_shapefuns_domain
   max_order = maximum(map(get_order,ctype_reffe))

--- a/src/FESpaces/ConformingFESpaces.jl
+++ b/src/FESpaces/ConformingFESpaces.jl
@@ -95,14 +95,14 @@ function CellFE(
   model::DiscreteModel,
   cell_reffe::AbstractArray{<:ReferenceFE},
   conformity::Conformity,
-  cell_fe_args...
+  args...
  )
   cell_conformity = CellConformity(cell_reffe,conformity)
   ctype_reffe, cell_ctype = compress_cell_data(cell_reffe)
   ctype_num_dofs = map(num_dofs,ctype_reffe)
   ctype_ldof_comp = map(reffe->get_dof_to_comp(reffe),ctype_reffe)
-  cell_shapefuns = get_cell_shapefuns(model,cell_reffe,conformity,cell_fe_args...)
-  cell_dof_basis = get_cell_dof_basis(model,cell_reffe,conformity,cell_fe_args...)
+  cell_shapefuns = get_cell_shapefuns(model,cell_reffe,conformity,args...)
+  cell_dof_basis = get_cell_dof_basis(model,cell_reffe,conformity,args...)
   cell_shapefuns_domain = ReferenceDomain()
   cell_dof_basis_domain = cell_shapefuns_domain
   max_order = maximum(map(get_order,ctype_reffe))

--- a/src/FESpaces/DivConformingFESpaces.jl
+++ b/src/FESpaces/DivConformingFESpaces.jl
@@ -28,8 +28,11 @@ struct TransformRTDofBasis{Dc,Dp} <: Map end ;
 
 function get_cell_dof_basis(model::DiscreteModel,
                             cell_reffe::AbstractArray{<:GenericRefFE{RaviartThomas}},
-                            ::DivConformity)
-    sign_flip = get_sign_flip(model, cell_reffe)
+                            ::DivConformity,
+                            sign_flip=nothing)
+    if (sign_flip==nothing)
+      sign_flip = get_sign_flip(model, cell_reffe)
+    end
     cell_map  = get_cell_map(Triangulation(model))
     phi       = cell_map[1]
     Jt        = lazy_map(Broadcasting(∇),cell_map)
@@ -46,8 +49,11 @@ end
 
 function get_cell_shapefuns(model::DiscreteModel,
                             cell_reffe::AbstractArray{<:GenericRefFE{RaviartThomas}},
-                            ::DivConformity)
-    sign_flip = get_sign_flip(model, cell_reffe)
+                            ::DivConformity,
+                            sign_flip=nothing)
+    if (sign_flip==nothing)
+      sign_flip = get_sign_flip(model, cell_reffe)
+    end
     cell_reffe_shapefuns=lazy_map(get_shapefuns,cell_reffe)
     k=ContraVariantPiolaMap()
     lazy_map(k,

--- a/src/FESpaces/DivConformingFESpaces.jl
+++ b/src/FESpaces/DivConformingFESpaces.jl
@@ -29,10 +29,7 @@ struct TransformRTDofBasis{Dc,Dp} <: Map end ;
 function get_cell_dof_basis(model::DiscreteModel,
                             cell_reffe::AbstractArray{<:GenericRefFE{RaviartThomas}},
                             ::DivConformity,
-                            sign_flip=nothing)
-    if (sign_flip==nothing)
-      sign_flip = get_sign_flip(model, cell_reffe)
-    end
+                            sign_flip=get_sign_flip(model, cell_reffe))
     cell_map  = get_cell_map(Triangulation(model))
     phi       = cell_map[1]
     Jt        = lazy_map(Broadcasting(∇),cell_map)
@@ -50,10 +47,7 @@ end
 function get_cell_shapefuns(model::DiscreteModel,
                             cell_reffe::AbstractArray{<:GenericRefFE{RaviartThomas}},
                             ::DivConformity,
-                            sign_flip=nothing)
-    if (sign_flip==nothing)
-      sign_flip = get_sign_flip(model, cell_reffe)
-    end
+                            sign_flip=get_sign_flip(model, cell_reffe))
     cell_reffe_shapefuns=lazy_map(get_shapefuns,cell_reffe)
     k=ContraVariantPiolaMap()
     lazy_map(k,

--- a/src/FESpaces/FESpaceFactories.jl
+++ b/src/FESpaces/FESpaceFactories.jl
@@ -64,21 +64,19 @@ end
 
 function FESpace(
   t::Triangulation,
-  cell_reffe::AbstractArray{<:ReferenceFE},
-  cell_fe_args...;
+  cell_reffe::AbstractArray{<:ReferenceFE};
   trian=nothing,
   kwargs...)
   @assert trian === nothing
   # TODO for L2 conformity and no dirichlet conditions
   # no needed to build the active model
   model = get_active_model(t)
-  FESpace(model,cell_reffe,cell_fe_args...;trian=t,kwargs...)
+  FESpace(model,cell_reffe;trian=t,kwargs...)
 end
 
 function FESpace(
   model::DiscreteModel,
-  cell_reffe::AbstractArray{<:ReferenceFE},
-  cell_fe_args...;
+  cell_reffe::AbstractArray{<:ReferenceFE};
   conformity=nothing,
   trian = Triangulation(model),
   labels = get_face_labeling(model),
@@ -104,7 +102,7 @@ function FESpace(
     return V
   end
 
-  cell_fe = CellFE(model,cell_reffe,conf,cell_fe_args...)
+  cell_fe = CellFE(model,cell_reffe,conf)
   _vector_type = _get_vector_type(vector_type,cell_fe,trian)
   if conformity in (L2Conformity(),:L2) && dirichlet_tags == Int[]
     F = _DiscontinuousFESpace(_vector_type,trian,cell_fe)
@@ -122,18 +120,16 @@ function FESpace(
 end
 
 function FESpace(model::DiscreteModel,
-                 reffe::Tuple{<:ReferenceFEName,Any,Any},
-                 cell_fe_args...; kwargs...)
+                 reffe::Tuple{<:ReferenceFEName,Any,Any}; kwargs...)
   basis, reffe_args,reffe_kwargs = reffe
   cell_reffe = ReferenceFE(model,basis,reffe_args...;reffe_kwargs...)
-  FESpace(model,cell_reffe,cell_fe_args...;kwargs...)
+  FESpace(model,cell_reffe;kwargs...)
 end
 
 function FESpace(model::DiscreteModel,
-                 reffe::ReferenceFE,
-                 cell_fe_args...; kwargs...)
+                 reffe::ReferenceFE; kwargs...)
   cell_reffe = Fill(reffe,num_cells(model))
-  FESpace(model,cell_reffe,cell_fe_args...;kwargs...)
+  FESpace(model,cell_reffe;kwargs...)
 end
 
 """

--- a/src/FESpaces/FESpaceFactories.jl
+++ b/src/FESpaces/FESpaceFactories.jl
@@ -64,19 +64,21 @@ end
 
 function FESpace(
   t::Triangulation,
-  cell_reffe::AbstractArray{<:ReferenceFE};
+  cell_reffe::AbstractArray{<:ReferenceFE},
+  cell_fe_args...;
   trian=nothing,
   kwargs...)
   @assert trian === nothing
   # TODO for L2 conformity and no dirichlet conditions
   # no needed to build the active model
   model = get_active_model(t)
-  FESpace(model,cell_reffe;trian=t,kwargs...)
+  FESpace(model,cell_reffe,cell_fe_args...;trian=t,kwargs...)
 end
 
 function FESpace(
   model::DiscreteModel,
-  cell_reffe::AbstractArray{<:ReferenceFE};
+  cell_reffe::AbstractArray{<:ReferenceFE},
+  cell_fe_args...;
   conformity=nothing,
   trian = Triangulation(model),
   labels = get_face_labeling(model),
@@ -102,7 +104,7 @@ function FESpace(
     return V
   end
 
-  cell_fe = CellFE(model,cell_reffe,conf)
+  cell_fe = CellFE(model,cell_reffe,conf,cell_fe_args...)
   _vector_type = _get_vector_type(vector_type,cell_fe,trian)
   if conformity in (L2Conformity(),:L2) && dirichlet_tags == Int[]
     F = _DiscontinuousFESpace(_vector_type,trian,cell_fe)
@@ -119,15 +121,19 @@ function FESpace(
   return V
 end
 
-function FESpace(model::DiscreteModel, reffe::Tuple{<:ReferenceFEName,Any,Any}; kwargs...)
+function FESpace(model::DiscreteModel,
+                 reffe::Tuple{<:ReferenceFEName,Any,Any},
+                 cell_fe_args...; kwargs...)
   basis, reffe_args,reffe_kwargs = reffe
   cell_reffe = ReferenceFE(model,basis,reffe_args...;reffe_kwargs...)
-  FESpace(model,cell_reffe;kwargs...)
+  FESpace(model,cell_reffe,cell_fe_args...;kwargs...)
 end
 
-function FESpace(model::DiscreteModel, reffe::ReferenceFE; kwargs...)
+function FESpace(model::DiscreteModel,
+                 reffe::ReferenceFE,
+                 cell_fe_args...; kwargs...)
   cell_reffe = Fill(reffe,num_cells(model))
-  FESpace(model,cell_reffe;kwargs...)
+  FESpace(model,cell_reffe,cell_fe_args...;kwargs...)
 end
 
 """


### PR DESCRIPTION
@fverdugo @santiagobadia 

This PR includes a set of changes I have required in order to implement my current approach for globally consistent parallel RT spaces in GridapDistributed.jl. (see https://github.com/gridap/GridapDistributed.jl/pull/64 for more details). Let me know your thoughs (perhaps there are better approaches, but I think this is a resonable one, e.g., it does not introduce breaking release changes in Gridap).

To be merged after PR #726