### PR TITLE
Bugfix in `reference_grid(TET)`

### DIFF
--- a/src/Geometry/Grids.jl
+++ b/src/Geometry/Grids.jl
@@ -357,7 +357,7 @@ function _compute_linear_grid_coords_from_simplex(p::Polytope{3},n::Integer)
   v(n,i,j,k) = tet_num(n) - tet_num(n-i+1) + v(n-i+1,j,k)
   @assert is_simplex(p)
   D = 3
-  cube_to_tets = ((1,2,3,5),(2,4,3,6),(3,5,7,6),(2,3,5,6),(3,4,7,6),(4,5,7,8))
+  cube_to_tets = ((1,2,3,5),(2,4,3,6),(3,5,7,6),(2,3,5,6),(3,4,7,6),(4,6,7,8))
   cube = CartesianIndices( (0:1,0:1,0:1) )
   n_core_tets = length(cube_to_tets)-2
   Tp = eltype(get_vertex_coordinates(p))

--- a/test/GeometryTests/GridsTests.jl
+++ b/test/GeometryTests/GridsTests.jl
@@ -66,16 +66,28 @@ grid = Grid(ReferenceFE{3},WEDGE)
 # Test linear grid
 
 grid = compute_reference_grid(TRI,5)
-Ω = Triangulation(UnstructuredDiscreteModel(grid))
-dΩ = Measure(Ω,2)
+model = UnstructuredDiscreteModel(grid)
+f_to_c = get_faces(get_grid_topology(model),1,2)
+num_boundary_facets =  num_facets(TRI)*5
+
+@test count(isequal(1),map(length,f_to_c)) == num_boundary_facets
+
+Ω_tri = Triangulation(model)
+dΩ = Measure(Ω_tri,2)
 
 test_grid(grid)
 
 @test sum( ∫(1)dΩ ) ≈ 1/2
 
 grid = compute_reference_grid(TET,5)
-Ω = Triangulation(UnstructuredDiscreteModel(grid))
-dΩ = Measure(Ω,2)
+model = UnstructuredDiscreteModel(grid)
+f_to_c = get_faces(get_grid_topology(model),2,3)
+num_boundary_facets = num_facets(TET)*num_cells(Ω_tri)
+
+@test count(isequal(1),map(length,f_to_c)) == num_boundary_facets
+
+Ω_tet = Triangulation(model)
+dΩ = Measure(Ω_tet,2)
 
 test_grid(grid)
 


### PR DESCRIPTION
Dear @fverdugo ,
this an small bugfix on the changes introduced in #704 

The new tests also checks that only the boundary facets have one single cell around.