### PR TITLE
Added dummy `parts` argument in CartesianDiscreteModel to mimic the API in GridapDistributed

### DIFF
--- a/src/Geometry/CartesianDiscreteModels.jl
+++ b/src/Geometry/CartesianDiscreteModels.jl
@@ -69,6 +69,10 @@ function CartesianDiscreteModel(args...; kwargs...)
   CartesianDiscreteModel(desc)
 end
 
+# Introduced to mimic the API in GridapDistributed
+function CartesianDiscreteModel(parts::Nothing,args...;kwargs...)
+  CartesianDiscreteModel(args...;kwargs...)
+end
 
 """
     get_cartesian_descriptor(model::CartesianDiscreteModel)

--- a/test/GeometryTests/CartesianDiscreteModelsTests.jl
+++ b/test/GeometryTests/CartesianDiscreteModelsTests.jl
@@ -10,6 +10,12 @@ using Test
 
 domain = (0,1,0,1,0,1)
 partition = (3,3,3)
+parts = nothing
+model = CartesianDiscreteModel(parts,domain,partition)
+test_discrete_model(model)
+
+domain = (0,1,0,1,0,1)
+partition = (3,3,3)
 model = CartesianDiscreteModel(domain,partition)
 test_discrete_model(model)
 @test is_oriented(get_grid(model)) == true


### PR DESCRIPTION
@amartinhuertas, @oriolcg and I ended up with this trick to easily jump from serial to distributed computations.

 Example: Changing a single line to jump from serial to distributed

```julia
parts = nothing # Use this for serial
parts = get_part_ids(...) # Use this for distributed

domain = (0,4,0,4)
cells = (4,4)
model = CartesianDiscreteModel(parts,domain,cells)
labels = get_face_labeling(model)
add_tag_from_tags!(labels,"dirichlet",[1,2,3,5,7])
add_tag_from_tags!(labels,"neumann",[4,6,8])

Ω = Triangulation(model)
Γn = Boundary(model,tags="neumann")
n_Γn = get_normal_vector(Γn)

k = 2
u((x,y)) = (x+y)^k
f(x) = -Δ(u,x)
g = n_Γn⋅∇(u)

reffe = ReferenceFE(lagrangian,Float64,k)
V = TestFESpace(model,reffe,dirichlet_tags="dirichlet")
U = TrialFESpace(u,V)

dΩ = Measure(Ω,2*k)
dΓn = Measure(Γn,2*k)

a(u,v) = ∫( ∇(v)⋅∇(u) )dΩ
l(v) = ∫( v*f )dΩ + ∫( v*g )dΓn
op = AffineFEOperator(a,l,U,V)

uh = solve(op)

```