### PR TITLE
Changed the method for `SkeletonCellFieldPair` for AD to work with operations inside `mean` and `jump`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added functionality to take gradient of functional involving integration (`DomainContribution`) over Skeleton faces, with respect to the degrees-of-freedom `FEFunction`.  The interface remains the same - `gradient(f,uh)`. Since PR [#797](https://github.com/gridap/Gridap.jl/pull/797)
 - Extended the `MultiField` functional gradient (with respect to degrees-of-freedom of `MultiFieldFEFunction`) to functionals involving Skeleton integration. The interface remains the same `gradient(f,xh)`. Since PR [#799](https://github.com/gridap/Gridap.jl/pull/799)
 
+### Fixed
+- Fixed the behavior of `gradient` for functionals involving operations of `CellFields` inside `mean` and `jump` terms of Skeleton Integration terms. Since PR [#800](https://github.com/gridap/Gridap.jl/pull/800)
+- Fixed the behavior `SkeletonCellFieldPair` at the Boundary integration terms. Since PR [#800](https://github.com/gridap/Gridap.jl/pull/800)
+
 ## [0.17.13] - 2022-05-31
 
 ### Added

--- a/src/CellData/SkeletonCellFieldPair.jl
+++ b/src/CellData/SkeletonCellFieldPair.jl
@@ -68,10 +68,6 @@ function get_triangulation(a::SkeletonCellFieldPair)
 end
 
 #=
-The below change_domain has been overloaded for SkeletonCellFieldPair
-to work without errors for integrations over other triangulation - Ω
-(BodyFittedTriangulation) and Γ (BoundaryTriangulation).
-
 We arbitrarily choose plus side of SkeletonCellFieldPair for evaluations, as
 we don't use the DomainContributions associated with Ω and Γ while performing
 the sensitivities for SkeletonTriangulation (Λ) DomainContribution. This
@@ -83,17 +79,6 @@ evaluations are all lazy and not used, this doesn't put any noticable memory
 or computational overhead. Ofcourse, it is made sure that the such plus side
 pick doesn't happen when the integration over the SkeletonTriangulation
 =#
-# function change_domain(a::SkeletonCellFieldPair,target_trian::Triangulation,target_domain::DomainStyle)
-#   change_domain(a.plus,DomainStyle(a),target_trian,target_domain)
-# end
-#=
-The above is not good because it converts a SkeletonCellFieldPair involved
-in an operation inside mean or jump, for example the one resulting from the
-expression mean(uh*uh), into its plus side, as the change_domain acts while
-building the internal operation tree, in the example for * operator and this
-gives wrong result as it chooses plus even for the case of Skeleton integration
-=#
-
 # If SkeletonCellFieldPair is evaluated we just pick the plus side parent
 function evaluate!(cache,f::SkeletonCellFieldPair,x::CellPoint)
   _f, _x = _to_common_domain(f.plus.parent,x)

--- a/test/MultiFieldTests/MultiFieldFEAutodiffTests.jl
+++ b/test/MultiFieldTests/MultiFieldFEAutodiffTests.jl
@@ -156,7 +156,7 @@ dΛ = Measure(Λ,2)
 n_Λ = get_normal_vector(Λ)
 
 g_Λ((uh,ph)) = ∫( mean(uh) + mean(ph) + mean(uh)*mean(ph) )dΛ
-# f_Λ((uh,ph)) = ∫( mean(uh*uh) + mean(uh*ph) + mean(ph*ph) )dΛ
+f_Λ((uh,ph)) = ∫( mean(uh*uh) + mean(uh*ph) + mean(ph*ph) )dΛ
 a_Λ((uh,ph)) = ∫( - jump(uh*n_Λ)⊙mean(∇(ph))
                   - mean(∇(uh))⊙jump(ph*n_Λ)
                   + jump(uh*n_Λ)⊙jump(ph*n_Λ) )dΛ
@@ -175,13 +175,13 @@ end
 # can also do the above by constructing a MultiFieldCellField
 
 g_Λ_(θ) = f_uh_free_dofs(g_Λ,xh,θ)
-# f_Λ_(θ) = f_uh_free_dofs(f_Λ,xh,θ)
+f_Λ_(θ) = f_uh_free_dofs(f_Λ,xh,θ)
 a_Λ_(θ) = f_uh_free_dofs(a_Λ,xh,θ)
 
 θ = get_free_dof_values(xh)
 
 # check if the evaluations are working
-# @test sum(f_Λ(xh)) == f_Λ_(θ)
+@test sum(f_Λ(xh)) == f_Λ_(θ)
 @test sum(a_Λ(xh)) == a_Λ_(θ)
 @test sum(g_Λ(xh)) == g_Λ_(θ)
 
@@ -190,6 +190,10 @@ f_Ω_(θ) = f_uh_free_dofs(f_Ω,xh,θ)
 gridapgradf_Ω = assemble_vector(gradient(f_Ω,xh),X)
 fdgradf_Ω = ForwardDiff.gradient(f_Ω_,θ)
 test_array(gridapgradf_Ω,fdgradf_Ω,≈)
+
+gridapgradf = assemble_vector(gradient(f_Λ,xh),X)
+fdgradf = ForwardDiff.gradient(f_Λ_,θ)
+test_array(gridapgradf,fdgradf,≈)
 
 gridapgradg = assemble_vector(gradient(g_Λ,xh),X)
 fdgradg = ForwardDiff.gradient(g_Λ_,θ)


### PR DESCRIPTION
* Overloaded the `evaluate!` method for `SkeletonCellFieldPair`
* removed the `change_domain` call resulting in wrong behaviour with terms involving operations of `CellFields` inside `mean` and `jump` terms 
* added both `SingleField` and `MultiField` AD tests compared with `ForwardDiff` for such terms 