### PR TITLE
added `lastindex` for MultiValue and tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `lastindex` for `MultiValue`s for consistent usage of `[end]` as per `length`. Since PR [#834](https://github.com/gridap/Gridap.jl/pull/834)
+- BDM (Brezzi-Douglas-Marini) ReferenceFEs in PR [#823](https://github.com/gridap/Gridap.jl/pull/823)
 
 ## [0.17.14] - 2022-07-29
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- `lastindex` for `MultiValue`s for consistent usage of `[end]` as per `length`. Since PR [#834](https://github.com/gridap/Gridap.jl/pull/834)
+
 ## [0.17.14] - 2022-07-29
 
 ### Added

--- a/src/TensorValues/Indexing.jl
+++ b/src/TensorValues/Indexing.jl
@@ -1,6 +1,8 @@
 
 eachindex(arg::MultiValue) = eachindex(1:prod(size(arg)))
 
+lastindex(arg::MultiValue) = length(arg)
+
 CartesianIndices(arg::MultiValue) = CartesianIndices(size(arg))
 
 LinearIndices(arg::MultiValue) = LinearIndices(size(arg))
@@ -78,4 +80,3 @@ function _4d_sym_tensor_linear_index(D,i,j,k,l)
   index=(block_index-1)*block_length+element_index
   index
 end
-

--- a/src/TensorValues/TensorValues.jl
+++ b/src/TensorValues/TensorValues.jl
@@ -65,7 +65,7 @@ import Base: zero, one
 import Base: +, -, *, /, \, ==, ≈, isless
 import Base: conj
 import Base: sum, maximum, minimum
-import Base: getindex, iterate, eachindex
+import Base: getindex, iterate, eachindex, lastindex
 import Base: size, length, eltype
 import Base: reinterpret
 import Base: convert

--- a/test/TensorValuesTests/IndexingTests.jl
+++ b/test/TensorValuesTests/IndexingTests.jl
@@ -13,6 +13,7 @@ v = VectorValue{4}(a)
 
 @test size(v) == (4,)
 @test length(v) == 4
+@test lastindex(v) == length(v)
 
 for (k,i) in enumerate(eachindex(v))
   @test v[i] == a[k]
@@ -22,6 +23,7 @@ t = TensorValue{2}(a)
 
 @test size(t) == (2,2)
 @test length(t) == 4
+@test lastindex(t) == length(t)
 
 for (k,i) in enumerate(eachindex(t))
   @test t[i] == a[k]
@@ -40,6 +42,7 @@ t = TensorValue(convert(SMatrix{2,2,Int},s))
 
 @test size(s) == (2,2)
 @test length(s) == 4
+@test lastindex(s) == length(s)
 
 for (k,i) in enumerate(eachindex(t))
     @test s[i] == t[k]


### PR DESCRIPTION
Hi @amartinhuertas and @fverdugo, I have added the `lastindex` method for `MultiValue` for using `[end]` and to resolve ambiguity with `length` upon discussion with @amartinhuertas, as currently `lastindex` falls back to `Number`, returning 1, which is not consistent with `length` for the same argument, the above is a small fix for the same using `length` under the hood. 