### PR TITLE
Adding support to `DiracDelta` for generic points in the domain 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `lastindex` for `MultiValue`s for consistent usage of `[end]` as per `length`. Since PR [#834](https://github.com/gridap/Gridap.jl/pull/834)
 - BDM (Brezzi-Douglas-Marini) ReferenceFEs in PR [#823](https://github.com/gridap/Gridap.jl/pull/823)
 - Implemented `ConstantFESpace`. This space allows, e.g., to impose the mean value of the pressure via an additional unknown/equation (a Lagrange multiplier). Since PR [#836](https://github.com/gridap/Gridap.jl/pull/836)
-- Added support to construct `DiracDelta` at generic `Point`(s) in the domain. Since PR [#837](https://github.com/gridap/Gridap.jl/pull/837)
+- Methods to construct `DiracDelta` at generic `Point`(s) in the domain. Since PR [#837](https://github.com/gridap/Gridap.jl/pull/837)
+- some key missing `lastindex` and `end` tests belonging to PR [#834]. Since PR [#837](https://github.com/gridap/Gridap.jl/pull/837)
+
 ## [0.17.14] - 2022-07-29
 
 ### Added

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `lastindex` for `MultiValue`s for consistent usage of `[end]` as per `length`. Since PR [#834](https://github.com/gridap/Gridap.jl/pull/834)
 - BDM (Brezzi-Douglas-Marini) ReferenceFEs in PR [#823](https://github.com/gridap/Gridap.jl/pull/823)
 - Implemented `ConstantFESpace`. This space allows, e.g., to impose the mean value of the pressure via an additional unknown/equation (a Lagrange multiplier). Since PR [#836](https://github.com/gridap/Gridap.jl/pull/836)
-
+- Added support to construct `DiracDelta` at generic `Point`(s) in the domain. Since PR [#837](https://github.com/gridap/Gridap.jl/pull/837)
 ## [0.17.14] - 2022-07-29
 
 ### Added

--- a/src/CellData/DiracDeltas.jl
+++ b/src/CellData/DiracDeltas.jl
@@ -99,8 +99,10 @@ function DiracDelta(model::DiscreteModel{D}, p::Point{D,T}) where {D,T}
   cache = _point_to_cell_cache(KDTreeSearch(),trian)
   cell = _point_to_cell!(cache, p)
   trianv = TriangulationView(trian,[cell])
-  pquad = GenericQuadrature([p],[one(T)])
-  pmeas = Measure(CellQuadrature([pquad],[[p]],[[one(T)]],trianv,PhysicalDomain(),PhysicalDomain()))
+  point = [p]
+  weight = [one(T)]
+  pquad = GenericQuadrature(point,weight)
+  pmeas = Measure(CellQuadrature([pquad],[pquad.coordinates],[pquad.weights],trianv,PhysicalDomain(),PhysicalDomain()))
   GenericDiracDelta{0,D,NotGridEntity}(trianv,pmeas)
 end
 
@@ -111,7 +113,7 @@ function DiracDelta(model::DiscreteModel{D}, pvec::Vector{Point{D,T}}) where {D,
   cell_points = collect(values(cell_to_pindices))
   points = map(i->pvec[cell_points[i]], 1:length(cell_ids))
   weights_x_cell = collect.(Fill.(one(T),length.(cell_points)))
-  pquad = map(i -> GenericQuadrature(pvec[cell_points[i]],weights_x_cell[i]), 1:length(cell_ids))
+  pquad = map(i -> GenericQuadrature(points[i],weights_x_cell[i]), 1:length(cell_ids))
   trianv = Triangulation(trian,cell_ids)
   pmeas = Measure(CellQuadrature(pquad,points,weights_x_cell,trianv,PhysicalDomain(),PhysicalDomain()))
   GenericDiracDelta{0,D,NotGridEntity}(trianv,pmeas)

--- a/src/CellData/DiracDeltas.jl
+++ b/src/CellData/DiracDeltas.jl
@@ -88,11 +88,9 @@ end
 # For handling DiracDelta at a generic Point in the domain #
 
 function DiracDelta(x::Point{D,T}, model::DiscreteModel{D}) where {D,T}
-  # check if the point is inside an active cell, as it wouldn't be caught for
-  # user-defined functions (i.e. which are not CellFields)
   trian = Triangulation(model)
   cache1 = _point_to_cell_cache(KDTreeSearch(),trian)
-  cell = _point_to_cell!(cache1, x) # throws error if Point not in domain
+  cell = _point_to_cell!(cache1, x)
   point_grid = UnstructuredGrid([x])
   point_model = UnstructuredDiscreteModel(point_grid)
   point_trian = Triangulation(point_model)
@@ -101,11 +99,9 @@ function DiracDelta(x::Point{D,T}, model::DiscreteModel{D}) where {D,T}
 end
 
 function DiracDelta(v::Vector{Point{D,T}},model::DiscreteModel{D}) where {D,T}
-  # check if the points are inside an active cell
   trian = Triangulation(model)
   cache1 = _point_to_cell_cache(KDTreeSearch(),trian)
   cell = map(x -> _point_to_cell!(cache1, x), v)
-  # throws error if any Point not in domain
   point_grid = UnstructuredGrid(v)
   point_model = UnstructuredDiscreteModel(point_grid)
   point_trian = Triangulation(point_model)

--- a/src/CellData/DiracDeltas.jl
+++ b/src/CellData/DiracDeltas.jl
@@ -118,17 +118,3 @@ function DiracDelta(model::DiscreteModel{D}, pvec::Vector{Point{D,T}}) where {D,
   pmeas = Measure(CellQuadrature(pquad,points,weights_x_cell,trianv,PhysicalDomain(),PhysicalDomain()))
   GenericDiracDelta{0,D,NotGridEntity}(trianv,pmeas)
 end
-
-function evaluate!(cache,d::GenericDiracDelta{0,Dt,NotGridEntity},f::Function) where Dt
-  dc = DomainContribution()
-  quad_points = d.dΓ.quad.cell_point
-  weights = d.dΓ.quad.cell_weight
-  dc_Γ = zeros(eltype(eltype(weights)), length(weights))
-  for i in eachindex(weights)
-    for j in eachindex(weights[i])
-      @inbounds dc_Γ[i] += f(quad_points[i][j])*weights[i][j]
-    end
-  end
-  add_contribution!(dc,d.Γ,dc_Γ)
-  dc
-end

--- a/src/CellData/DiracDeltas.jl
+++ b/src/CellData/DiracDeltas.jl
@@ -94,7 +94,7 @@ function _cell_to_pindex(pvec::Vector{<:Point},trian::Triangulation)
   cell_to_pindex
 end
 
-function DiracDelta(p::Point{D,T}, model::DiscreteModel{D}) where {D,T}
+function DiracDelta(model::DiscreteModel{D}, p::Point{D,T}) where {D,T}
   trian = Triangulation(model)
   cache = _point_to_cell_cache(KDTreeSearch(),trian)
   cell = _point_to_cell!(cache, p)
@@ -104,7 +104,7 @@ function DiracDelta(p::Point{D,T}, model::DiscreteModel{D}) where {D,T}
   GenericDiracDelta{0,D,NotGridEntity}(trianv,pmeas)
 end
 
-function DiracDelta(pvec::Vector{Point{D,T}}, model::DiscreteModel{D}) where {D,T}
+function DiracDelta(model::DiscreteModel{D}, pvec::Vector{Point{D,T}}) where {D,T}
   trian = Triangulation(model)
   cell_to_pindices = _cell_to_pindex(pvec,trian)
   cell_ids = collect(keys(cell_to_pindices))
@@ -116,18 +116,3 @@ function DiracDelta(pvec::Vector{Point{D,T}}, model::DiscreteModel{D}) where {D,
   pmeas = Measure(CellQuadrature(pquad,points,weights_x_cell,trianv,PhysicalDomain(),PhysicalDomain()))
   GenericDiracDelta{0,D,NotGridEntity}(trianv,pmeas)
 end
-
-# TO DO: point_to_cell search cache needs to reused somehow
-# for Finite Element Function build using a fixed FE basis
-# since the basis remain fixed for each cell unless p or h
-# adapted, we can pre-compute them for given DiracDelta and
-# store them in cache. But for this we have to diverge from
-# the current Struct and add more attributes - like cache
-
-# GenericQuadrature doesn't taken FillArrays only Vectors
-# would be good to add this, as it would be useful here
-# The question is if it creates a problem down somewhere?
-# ofcourse excluding the tests which taken into account the types
-# like test_quadrature functions
-# if type independent problems exist for this generalization then
-# this is a more important problem

--- a/src/CellData/DiracDeltas.jl
+++ b/src/CellData/DiracDeltas.jl
@@ -87,10 +87,6 @@ end
 
 # For handling DiracDelta at a generic Point in the domain #
 
-function DiracDelta(x::Point{D}, model::DiscreteModel{D}) where D
-  DiracDelta(x, model)
-end
-
 function DiracDelta(x::Point{D,T}, model::DiscreteModel{D}) where {D,T}
   # check if the point is inside an active cell, as it wouldn't be caught for
   # user-defined functions (i.e. which are not CellFields)

--- a/src/CellData/DiracDeltas.jl
+++ b/src/CellData/DiracDeltas.jl
@@ -98,7 +98,7 @@ function DiracDelta(model::DiscreteModel{D}, p::Point{D,T}) where {D,T}
   trian = Triangulation(model)
   cache = _point_to_cell_cache(KDTreeSearch(),trian)
   cell = _point_to_cell!(cache, p)
-  trianv = TriangulationView(trian,[cell])
+  trianv = view(trian,[cell])
   point = [p]
   weight = [one(T)]
   pquad = GenericQuadrature(point,weight)
@@ -114,7 +114,7 @@ function DiracDelta(model::DiscreteModel{D}, pvec::Vector{Point{D,T}}) where {D,
   points = map(i->pvec[cell_points[i]], 1:length(cell_ids))
   weights_x_cell = collect.(Fill.(one(T),length.(cell_points)))
   pquad = map(i -> GenericQuadrature(points[i],weights_x_cell[i]), 1:length(cell_ids))
-  trianv = TriangulationView(trian,cell_ids)
+  trianv = view(trian,cell_ids)
   pmeas = Measure(CellQuadrature(pquad,points,weights_x_cell,trianv,PhysicalDomain(),PhysicalDomain()))
   GenericDiracDelta{0,D,NotGridEntity}(trianv,pmeas)
 end

--- a/src/CellData/DiracDeltas.jl
+++ b/src/CellData/DiracDeltas.jl
@@ -114,7 +114,7 @@ function DiracDelta(model::DiscreteModel{D}, pvec::Vector{Point{D,T}}) where {D,
   points = map(i->pvec[cell_points[i]], 1:length(cell_ids))
   weights_x_cell = collect.(Fill.(one(T),length.(cell_points)))
   pquad = map(i -> GenericQuadrature(points[i],weights_x_cell[i]), 1:length(cell_ids))
-  trianv = Triangulation(trian,cell_ids)
+  trianv = TriangulationView(trian,cell_ids)
   pmeas = Measure(CellQuadrature(pquad,points,weights_x_cell,trianv,PhysicalDomain(),PhysicalDomain()))
   GenericDiracDelta{0,D,NotGridEntity}(trianv,pmeas)
 end

--- a/src/Geometry/Geometry.jl
+++ b/src/Geometry/Geometry.jl
@@ -102,6 +102,7 @@ export compress_ids
 export UnstructuredGridTopology
 
 export Triangulation
+export TriangulationView
 export get_reffes
 export get_cell_coordinates
 export get_cell_ref_coordinates

--- a/src/Geometry/Geometry.jl
+++ b/src/Geometry/Geometry.jl
@@ -102,7 +102,6 @@ export compress_ids
 export UnstructuredGridTopology
 
 export Triangulation
-export TriangulationView
 export get_reffes
 export get_cell_coordinates
 export get_cell_ref_coordinates

--- a/test/CellDataTests/DiracDeltasTests.jl
+++ b/test/CellDataTests/DiracDeltasTests.jl
@@ -47,7 +47,7 @@ pvec = [p,π*p]
 δ = DiracDelta(pvec,model)
 @test sum(δ(v)) == sum(v(pvec))
 
-# below passes but cannot import FESpace and FEFunction here
+# below passes but cannot use FESpace and FEFunction here
 # reffe = ReferenceFE(lagrangian,Float64,3)
 # V = FESpace(model,reffe,conformity=:L2)
 # uh = FEFunction(V,rand(num_free_dofs(V)))

--- a/test/CellDataTests/DiracDeltasTests.jl
+++ b/test/CellDataTests/DiracDeltasTests.jl
@@ -146,6 +146,12 @@ uh_tag = solve(op)
 err = uh_p - uh_tag
 @test sum(∫(err*err)*dΩ) < eps()
 
+# testing the faster and direct functional evalulation method
+
+f(x) = sin(norm(x))
+fcf = CellField(f,Ω)
+@test sum(δ_p(f)) ≈ sum(δ_p(fcf))
+
 
 #using Gridap
 #

--- a/test/CellDataTests/DiracDeltasTests.jl
+++ b/test/CellDataTests/DiracDeltasTests.jl
@@ -37,6 +37,22 @@ degree = 2
 δ = DiracDelta{0}(model,tags=[2,4])
 @test sum(δ(v)) ≈ 5
 
+# Tests for DiracDelta at a generic Point in the domain #
+
+p = VectorValue(0.2,0.3)
+δ = DiracDelta(p,model)
+@test sum(δ(v)) == v(p)
+
+pvec = [p,π*p]
+δ = DiracDelta(pvec,model)
+@test sum(δ(v)) == sum(v(pvec))
+
+# below passes but cannot import FESpace and FEFunction here
+# reffe = ReferenceFE(lagrangian,Float64,3)
+# V = FESpace(model,reffe,conformity=:L2)
+# uh = FEFunction(V,rand(num_free_dofs(V)))
+# @test sum(d(uh)) == uh(p)
+
 #using Gridap
 #
 #order = 2

--- a/test/TensorValuesTests/IndexingTests.jl
+++ b/test/TensorValuesTests/IndexingTests.jl
@@ -14,6 +14,7 @@ v = VectorValue{4}(a)
 @test size(v) == (4,)
 @test length(v) == 4
 @test lastindex(v) == length(v)
+@test v[end] == a[end]
 
 for (k,i) in enumerate(eachindex(v))
   @test v[i] == a[k]
@@ -24,6 +25,7 @@ t = TensorValue{2}(a)
 @test size(t) == (2,2)
 @test length(t) == 4
 @test lastindex(t) == length(t)
+@test t[end] == a[end]
 
 for (k,i) in enumerate(eachindex(t))
   @test t[i] == a[k]
@@ -43,6 +45,7 @@ t = TensorValue(convert(SMatrix{2,2,Int},s))
 @test size(s) == (2,2)
 @test length(s) == 4
 @test lastindex(s) == length(s)
+@test s[end] == 22 
 
 for (k,i) in enumerate(eachindex(t))
     @test s[i] == t[k]


### PR DESCRIPTION
Hi @santiagobadia and @amartinhuertas, I added methods to `DiracDelta` to support generic points in the domain, which are not grid entities with tags, would be glad to know your suggestions for improvement and changes. This PR is aimed at resolving the issue [#357]. Given that `CellField`s can now be evaluated at a generic point in the domain, the method make use of this to calculate the integral of the composition of `DiracDelta` with a `CellField`, and also works for generic functions compatible to evaluate at a `Gridap` `Point`. 

So as to conform with `DiracDelta` struct, a `DiscreteModel` is constructed with given set of `Point`s to generate `Triangulation` and `Measure`. If we are not required to conform with the existing framework, we could just store the `Point`s as a struct and evaluate the `CellField` point-wise directly, but the above doesn't create much overhead. And probably the later is not generic enough to be extendable to line and surface forcing terms. 

The usage is same as earlier but the constructor is as follows:

```julia
model = CartesianDiscreteModel((0,1,0,1),(3,3))
p = Point(0.1,0.2)
pvec = [p, 1.5*p]
δ = DiracDelta(model,p)
δ_comb = DiracDelta(model,pvec)
```

[WIP] TO DO: support for line and surface loads! (like presented here https://github.com/gridap/Gridap.jl/issues/408#issuecomment-734929575). I think the line load case is extendable in a straight forward manner using `CartesianDiscreteModel` (but may be needs to be done separately for each line - defined by a pair of points..)