### PR TITLE
Made GenericQuadrature general to accept AbstractVectors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implemented `ConstantFESpace`. This space allows, e.g., to impose the mean value of the pressure via an additional unknown/equation (a Lagrange multiplier). Since PR [#836](https://github.com/gridap/Gridap.jl/pull/836)
 - Methods to construct `DiracDelta` at generic `Point`(s) in the domain. Since PR [#837](https://github.com/gridap/Gridap.jl/pull/837)
 - some key missing `lastindex` and `end` tests belonging to PR [#834]. Since PR [#837](https://github.com/gridap/Gridap.jl/pull/837)
-
+- `AbstractVector` support to weights and `Point`s of GenericQuadrature, in particular for `FillArray` usage. Since PR [#839](https://github.com/gridap/Gridap.jl/pull/839)
+- Using the above generalization of `GenericQuadrature`, made the weights of quadrature of `DiracDelta` for generic points to be a `Fill` vector. Since PR [#839](https://github.com/gridap/Gridap.jl/pull/839)
+ 
 ## [0.17.14] - 2022-07-29
 
 ### Added

--- a/src/CellData/DiracDeltas.jl
+++ b/src/CellData/DiracDeltas.jl
@@ -112,7 +112,7 @@ function DiracDelta(model::DiscreteModel{D}, pvec::Vector{Point{D,T}}) where {D,
   cell_ids = collect(keys(cell_to_pindices))
   cell_points = collect(values(cell_to_pindices))
   points = map(i->pvec[cell_points[i]], 1:length(cell_ids))
-  weights_x_cell = collect.(Fill.(one(T),length.(cell_points)))
+  weights_x_cell = Fill.(one(T),length.(cell_points))
   pquad = map(i -> GenericQuadrature(points[i],weights_x_cell[i]), 1:length(cell_ids))
   trianv = view(trian,cell_ids)
   pmeas = Measure(CellQuadrature(pquad,points,weights_x_cell,trianv,PhysicalDomain(),PhysicalDomain()))

--- a/src/ReferenceFEs/Quadratures.jl
+++ b/src/ReferenceFEs/Quadratures.jl
@@ -62,8 +62,8 @@ num_dims(::Type{<:Quadrature{D}}) where D = D
 function test_quadrature(q::Quadrature{D,T}) where {D,T}
   x = get_coordinates(q)
   w = get_weights(q)
-  @test isa(x,Vector{Point{D,T}})
-  @test isa(w,Vector{T})
+  @test isa(x,AbstractVector{Point{D,T}})
+  @test isa(w,AbstractVector{T})
   @test length(x) == num_points(q)
   @test length(w) == num_points(q)
   @test D == num_dims(q)
@@ -75,20 +75,20 @@ end
 # Generic concrete implementation
 
 """
-    struct GenericQuadrature{D,T} <: Quadrature{D,T}
+    struct GenericQuadrature{D,T,C <: AbstractVector{Point{D,T}},W <: AbstractVector{T}} <: Quadrature{D,T}
       coordinates::Vector{Point{D,T}}
       weights::Vector{T}
       name::String
     end
 """
-struct GenericQuadrature{D,T} <: Quadrature{D,T}
-  coordinates::Vector{Point{D,T}}
-  weights::Vector{T}
+struct GenericQuadrature{D,T,C <: AbstractVector{Point{D,T}},W <: AbstractVector{T}} <: Quadrature{D,T}
+  coordinates::C
+  weights::W
   name::String
 end
 
 function GenericQuadrature(
-  coordinates::Vector{Point{D,T}}, weights::Vector{T}) where {D,T}
+  coordinates::AbstractVector{Point{D,T}}, weights::AbstractVector{T}) where {D,T}
   name = "Unknown"
   GenericQuadrature(coordinates,weights,name)
 end

--- a/test/ReferenceFEsTests/QuadraturesTests.jl
+++ b/test/ReferenceFEsTests/QuadraturesTests.jl
@@ -2,9 +2,15 @@ module QuadraturesTests
 
 using Gridap.Fields
 using Gridap.ReferenceFEs
+using FillArrays
 
 coords = Point{2,Float64}[(0.0,0.0),(0.5,0.5),(1.0,1.0)]
 weights = [0.5, 1.0, 0.5]
+quad = GenericQuadrature(coords,weights)
+test_quadrature(quad)
+
+coords = Point{2,Float64}[(0.0,0.0),(0.5,0.5),(1.0,1.0)]
+weights = Fill(1.0,3)
 quad = GenericQuadrature(coords,weights)
 test_quadrature(quad)
 


### PR DESCRIPTION
- This is particularly useful to pass weights of quadratures as `FillArrays`
- Very useful in `DiracDelta` quadrature setup and also to write something like Monte Carlo quadrature 
- Related testing mechanism has been modified accordingly and a test has been added 
- Already used now in the `DiracDelta` for generic points 