### PR TITLE
Adding support for quadrature in `Float32` precision

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - some key missing `lastindex` and `end` tests belonging to PR [#834]. Since PR [#837](https://github.com/gridap/Gridap.jl/pull/837)
 - `AbstractVector` support to weights and `Point`s of GenericQuadrature, in particular for `FillArray` usage. Since PR [#839](https://github.com/gridap/Gridap.jl/pull/839)
 - Using the above generalization of `GenericQuadrature`, made the weights of quadrature of `DiracDelta` for generic points to be a `Fill` vector. Since PR [#839](https://github.com/gridap/Gridap.jl/pull/839)
-- Optional keyword argument `fptype` to select the floating point precision for the numerical quadrature pipeline involving `Measure`, `CellQuadrature` and `Quadrature` functions. `fptype` defaults to `Float64` when not specified, so it doesn't involve any breaking changes in public API. Since PR [#840](https://github.com/gridap/Gridap.jl/pull/840)
+- Optional keyword argument `T` to select the floating point precision for the numerical quadrature pipeline involving `Measure`, `CellQuadrature` and `Quadrature` functions. `T` defaults to `Float64` when not specified, so it doesn't involve any breaking changes in public API. Since PR [#840](https://github.com/gridap/Gridap.jl/pull/840)
  
 ## [0.17.14] - 2022-07-29
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - some key missing `lastindex` and `end` tests belonging to PR [#834]. Since PR [#837](https://github.com/gridap/Gridap.jl/pull/837)
 - `AbstractVector` support to weights and `Point`s of GenericQuadrature, in particular for `FillArray` usage. Since PR [#839](https://github.com/gridap/Gridap.jl/pull/839)
 - Using the above generalization of `GenericQuadrature`, made the weights of quadrature of `DiracDelta` for generic points to be a `Fill` vector. Since PR [#839](https://github.com/gridap/Gridap.jl/pull/839)
+- Optional keyword argument `fptype` to select the floating point precision for the numerical quadrature pipeline involving `Measure`, `CellQuadrature` and `Quadrature` functions. `fptype` defaults to `Float64` when not specified, so it doesn't involve any breaking changes in public API. Since PR [#840](https://github.com/gridap/Gridap.jl/pull/840)
  
 ## [0.17.14] - 2022-07-29
 

--- a/src/CellData/CellQuadratures.jl
+++ b/src/CellData/CellQuadratures.jl
@@ -33,12 +33,12 @@ function CellQuadrature(trian::Triangulation,quad::Tuple{<:QuadratureName,Any,An
   CellQuadrature(trian,cell_quad,ids)
 end
 
-function CellQuadrature(trian::Triangulation,degree::Integer)
-  CellQuadrature(trian,degree,PhysicalDomain())
+function CellQuadrature(trian::Triangulation,degree::Integer;kwargs...)
+  CellQuadrature(trian,degree,PhysicalDomain();kwargs...)
 end
 
-function CellQuadrature(trian::Triangulation,degree::Integer,ids::DomainStyle)
-  cell_quad = Quadrature(trian,degree)
+function CellQuadrature(trian::Triangulation,degree::Integer,ids::DomainStyle;kwargs...)
+  cell_quad = Quadrature(trian,degree;kwargs...)
   CellQuadrature(trian,cell_quad,ids)
 end
 

--- a/src/CellData/CellQuadratures.jl
+++ b/src/CellData/CellQuadratures.jl
@@ -66,22 +66,22 @@ function CellQuadrature(trian::Triangulation,
   CellQuadrature(cell_quad,cell_point,cell_weight,trian,ReferenceDomain(),ids)
 end
 
-function CellQuadrature(trian::AppendedTriangulation,degree1,degree2)
-  CellQuadrature(trian,degree1,degree2,PhysicalDomain())
+function CellQuadrature(trian::AppendedTriangulation,degree1,degree2;kwargs...)
+  CellQuadrature(trian,degree1,degree2,PhysicalDomain();kwargs...)
 end
 
-function CellQuadrature(trian::AppendedTriangulation,degree1,degree2,ids::DomainStyle)
-  quad1 = CellQuadrature(trian.a,degree1,ids)
-  quad2 = CellQuadrature(trian.b,degree2,ids)
+function CellQuadrature(trian::AppendedTriangulation,degree1,degree2,ids::DomainStyle;kwargs...)
+  quad1 = CellQuadrature(trian.a,degree1,ids;kwargs...)
+  quad2 = CellQuadrature(trian.b,degree2,ids;kwargs...)
   lazy_append(quad1,quad2,trian)
 end
 
-function CellQuadrature(trian::AppendedTriangulation,degree::Integer)
-  CellQuadrature(trian,degree,degree,PhysicalDomain())
+function CellQuadrature(trian::AppendedTriangulation,degree::Integer;kwargs...)
+  CellQuadrature(trian,degree,degree,PhysicalDomain();kwargs...)
 end
 
-function CellQuadrature(trian::AppendedTriangulation,degree::Integer,ids::DomainStyle)
-  CellQuadrature(trian,degree,degree,ids)
+function CellQuadrature(trian::AppendedTriangulation,degree::Integer,ids::DomainStyle;kwargs...)
+  CellQuadrature(trian,degree,degree,ids;kwargs...)
 end
 
 function CellQuadrature(trian::AppendedTriangulation,

--- a/src/CellData/DomainContributions.jl
+++ b/src/CellData/DomainContributions.jl
@@ -119,7 +119,7 @@ end
 
 get_cell_points(a::Measure) = get_cell_points(a.quad)
 
-Measure(args...) = Measure(CellQuadrature(args...))
+Measure(args...;kwargs...) = Measure(CellQuadrature(args...;kwargs...))
 
 function integrate(f,b::Measure)
   c = integrate(f,b.quad)

--- a/src/ReferenceFEs/DuffyQuadratures.jl
+++ b/src/ReferenceFEs/DuffyQuadratures.jl
@@ -25,11 +25,11 @@ function _duffy_quad_data(order::Integer,D::Int;fptype::Type{<:AbstractFloat}=Fl
   dim_to_xs_1d = [quad_1d[x_pos] for quad_1d in dim_to_quad_1d]
   dim_to_ws_1d = [quad_1d[w_pos] for quad_1d in dim_to_quad_1d]
 
-  a = 0.5
+  a = fptype(0.5)
   for d in (D-1):-1:1
     ws_1d = dim_to_ws_1d[d]
     ws_1d[:] *= a
-    a *= 0.5
+    a *= fptype(0.5)
   end
 
   x,w = _tensor_product_duffy(dim_to_xs_1d,dim_to_ws_1d)
@@ -96,8 +96,9 @@ end
 function _tensor_product_duffy!(
   xs,ws,dim_to_xs_1d,dim_to_ws_1d,cis::CartesianIndices{D},m) where D
   k = 1
+  T = eltype(ws)
   for ci in cis
-    w = 1.0
+    w = one(T)
     for d in 1:D
       xs_1d = dim_to_xs_1d[d]
       ws_1d = dim_to_ws_1d[d]

--- a/src/ReferenceFEs/DuffyQuadratures.jl
+++ b/src/ReferenceFEs/DuffyQuadratures.jl
@@ -3,21 +3,21 @@ struct Duffy <: QuadratureName end
 
 const duffy = Duffy()
 
-function Quadrature(p::Polytope,name::Duffy,degree::Integer;fptype::Type{<:AbstractFloat}=Float64)
+function Quadrature(p::Polytope,name::Duffy,degree::Integer;T::Type{<:AbstractFloat}=Float64)
   @assert is_simplex(p)
   D = num_dims(p)
-  x,w = _duffy_quad_data(degree,D,fptype=fptype)
+  x,w = _duffy_quad_data(degree,D,T=T)
   msg = "Simplex quadrature of degree $degree obtained with Duffy transformation and tensor product of 1d Gauss-Jacobi and Gauss-Legendre rules."
   GenericQuadrature(x,w,msg)
 end
 
-function _duffy_quad_data(order::Integer,D::Int;fptype::Type{<:AbstractFloat}=Float64)
+function _duffy_quad_data(order::Integer,D::Int;T::Type{<:AbstractFloat}=Float64)
 
   beta = 0
   dim_to_quad_1d = [
-    _gauss_jacobi_in_0_to_1(order,(D-1)-(d-1),beta;fptype=fptype) for d in 1:(D-1) ]
+    _gauss_jacobi_in_0_to_1(order,(D-1)-(d-1),beta;T=T) for d in 1:(D-1) ]
 
-  quad_1d = _gauss_legendre_in_0_to_1(order;fptype=fptype)
+  quad_1d = _gauss_legendre_in_0_to_1(order;T=T)
   push!(dim_to_quad_1d,quad_1d)
 
   x_pos = 1
@@ -25,11 +25,11 @@ function _duffy_quad_data(order::Integer,D::Int;fptype::Type{<:AbstractFloat}=Fl
   dim_to_xs_1d = [quad_1d[x_pos] for quad_1d in dim_to_quad_1d]
   dim_to_ws_1d = [quad_1d[w_pos] for quad_1d in dim_to_quad_1d]
 
-  a = fptype(0.5)
+  a = T(0.5)
   for d in (D-1):-1:1
     ws_1d = dim_to_ws_1d[d]
     ws_1d[:] *= a
-    a *= fptype(0.5)
+    a *= T(0.5)
   end
 
   x,w = _tensor_product_duffy(dim_to_xs_1d,dim_to_ws_1d)
@@ -52,16 +52,16 @@ end
 
 _duffy_map(q::Point{1,T}) where T = q
 
-function _gauss_jacobi_in_0_to_1(order,alpha,beta;fptype::Type{<:AbstractFloat}=Float64)
+function _gauss_jacobi_in_0_to_1(order,alpha,beta;T::Type{<:AbstractFloat}=Float64)
   n = _npoints_from_order(order)
   x,w = gaussjacobi(n,alpha,beta)
-  _map_to(0,1,x,w;T=fptype)
+  _map_to(0,1,x,w;T=T)
 end
 
-function _gauss_legendre_in_0_to_1(order;fptype::Type{<:AbstractFloat}=Float64)
+function _gauss_legendre_in_0_to_1(order;T::Type{<:AbstractFloat}=Float64)
   n = _npoints_from_order(order)
   x,w = gausslegendre(n)
-  _map_to(0,1,x,w;T=fptype)
+  _map_to(0,1,x,w;T=T)
 end
 
 # Transforms a 1-D quadrature from `[-1,1]` to `[a,b]`, with `a<b`.

--- a/src/ReferenceFEs/Quadratures.jl
+++ b/src/ReferenceFEs/Quadratures.jl
@@ -122,9 +122,9 @@ Quadrature(name::QuadratureName,args...;kwargs...) = (name, args, kwargs)
 """
     Quadrature(polytope::Polytope{D},degree) where D
 """
-function Quadrature(p::Polytope,degree;fptype::Type{<:AbstractFloat}=Float64)
+function Quadrature(p::Polytope,degree;T::Type{<:AbstractFloat}=Float64)
   if is_n_cube(p)
-    quad = Quadrature(p,tensor_product,degree;fptype=fptype)
+    quad = Quadrature(p,tensor_product,degree;T=T)
   elseif is_simplex(p)
     D = num_dims(p)
     #if (D==2 && degree in keys(_strang_tri_k2n)) ||
@@ -133,9 +133,9 @@ function Quadrature(p::Polytope,degree;fptype::Type{<:AbstractFloat}=Float64)
     # there are some 2d strang quadratures that are not accurate
     # as implemented here (to investigate why)
     if (D==3 && degree in keys(_strang_tet_k2n))
-      quad = Quadrature(p,strang,degree;fptype=fptype)
+      quad = Quadrature(p,strang,degree;T=T)
     else
-      quad = Quadrature(p,duffy,degree,fptype=fptype)
+      quad = Quadrature(p,duffy,degree,T=T)
     end
   else
     @notimplemented "Quadratures only implemented for n-cubes and simplices"

--- a/src/ReferenceFEs/Quadratures.jl
+++ b/src/ReferenceFEs/Quadratures.jl
@@ -122,9 +122,9 @@ Quadrature(name::QuadratureName,args...;kwargs...) = (name, args, kwargs)
 """
     Quadrature(polytope::Polytope{D},degree) where D
 """
-function Quadrature(p::Polytope,degree)
+function Quadrature(p::Polytope,degree;fptype::Type{<:AbstractFloat}=Float64)
   if is_n_cube(p)
-    quad = Quadrature(p,tensor_product,degree)
+    quad = Quadrature(p,tensor_product,degree;fptype=fptype)
   elseif is_simplex(p)
     D = num_dims(p)
     #if (D==2 && degree in keys(_strang_tri_k2n)) ||
@@ -133,9 +133,9 @@ function Quadrature(p::Polytope,degree)
     # there are some 2d strang quadratures that are not accurate
     # as implemented here (to investigate why)
     if (D==3 && degree in keys(_strang_tet_k2n))
-      quad = Quadrature(p,strang,degree)
+      quad = Quadrature(p,strang,degree;fptype=fptype)
     else
-      quad = Quadrature(p,duffy,degree)
+      quad = Quadrature(p,duffy,degree,fptype=fptype)
     end
   else
     @notimplemented "Quadratures only implemented for n-cubes and simplices"

--- a/src/ReferenceFEs/StrangQuadratures.jl
+++ b/src/ReferenceFEs/StrangQuadratures.jl
@@ -2,16 +2,16 @@
 struct Strang <: QuadratureName end
 const strang = Strang()
 
-function Quadrature(p::Polytope,::Strang,degree::Integer;fptype::Type{<:AbstractFloat}=Float64)
+function Quadrature(p::Polytope,::Strang,degree::Integer;T::Type{<:AbstractFloat}=Float64)
   msg = """\n
   `strang` quadrature rule only available for simplices.
   Use `tensor_product` for n-cubes.
   """
   @assert is_simplex(p) msg
   if num_dims(p) == 2
-    quad = _strang_quad_tri(degree;T=fptype)
+    quad = _strang_quad_tri(degree;T=T)
   elseif num_dims(p) == 3
-    quad = _strang_quad_tet(degree,T=fptype)
+    quad = _strang_quad_tet(degree,T=T)
   else
     msg = """\n
     `strang` quadrature rule only available for tris and tets.

--- a/src/ReferenceFEs/StrangQuadratures.jl
+++ b/src/ReferenceFEs/StrangQuadratures.jl
@@ -2,16 +2,16 @@
 struct Strang <: QuadratureName end
 const strang = Strang()
 
-function Quadrature(p::Polytope,::Strang,degree::Integer)
+function Quadrature(p::Polytope,::Strang,degree::Integer;fptype::Type{<:AbstractFloat}=Float64)
   msg = """\n
   `strang` quadrature rule only available for simplices.
   Use `tensor_product` for n-cubes.
   """
   @assert is_simplex(p) msg
   if num_dims(p) == 2
-    quad = _strang_quad_tri(degree)
+    quad = _strang_quad_tri(degree;T=fptype)
   elseif num_dims(p) == 3
-    quad = _strang_quad_tet(degree)
+    quad = _strang_quad_tet(degree,T=fptype)
   else
     msg = """\n
     `strang` quadrature rule only available for tris and tets.
@@ -24,7 +24,7 @@ end
 
 const _strang_tri_k2n = Dict(1=>1,2=>3,3=>4,4=>6,5=>7,7=>13,9=>19,11=>28)
 
-function _strang_quad_tri(degree)
+function _strang_quad_tri(degree;T::Type{<:AbstractFloat}=Float64)
   if ! haskey(_strang_tri_k2n,degree)
     msg = """\n
       `strang` quadrature rule not implemented for degree = $degree on a triangle.
@@ -34,8 +34,8 @@ function _strang_quad_tri(degree)
     error(msg)
   end
   n = _strang_tri_k2n[degree]
-  x = Vector{VectorValue{2,Float64}}(undef,n)
-  w = Vector{Float64}(undef,n)
+  x = Vector{VectorValue{2,T}}(undef,n)
+  w = Vector{T}(undef,n)
   if degree == 1
     a = 1.0/3.0
     b = 1.0/2.0
@@ -72,7 +72,7 @@ function _strang_quad_tri(degree)
     et2 = 0.445948490915965
     ez2 = 0.445948490915965
     a = 0.054975870996713638
-    b = 0.1116907969117165    
+    b = 0.1116907969117165
     x[1] = (et1,ez1)
     x[2] = (ez2,ex2)
     x[3] = (ex1,et1)
@@ -294,7 +294,7 @@ end
 
 const _strang_tet_k2n = Dict(1=>1,2=>4,3=>5,4=>11,5=>14)
 
-function _strang_quad_tet(degree)
+function _strang_quad_tet(degree;T::Type{<:AbstractFloat}=Float64)
   if ! haskey(_strang_tet_k2n,degree)
     msg = """\n
       `strang` quadrature rule not implemented for degree = $degree on a tet.
@@ -304,8 +304,8 @@ function _strang_quad_tet(degree)
     error(msg)
   end
   n = _strang_tet_k2n[degree]
-  x = Vector{VectorValue{3,Float64}}(undef,n)
-  w = Vector{Float64}(undef,n)
+  x = Vector{VectorValue{3,T}}(undef,n)
+  w = Vector{T}(undef,n)
   if degree==1
     a = 1.0/4.0
     b = 1.0/6.0

--- a/src/ReferenceFEs/TensorProductQuadratures.jl
+++ b/src/ReferenceFEs/TensorProductQuadratures.jl
@@ -3,17 +3,17 @@ struct TensorProduct <: QuadratureName end
 
 const tensor_product = TensorProduct()
 
-function Quadrature(p::Polytope,::TensorProduct,degrees;fptype::Type{<:AbstractFloat}=Float64)
+function Quadrature(p::Polytope,::TensorProduct,degrees;T::Type{<:AbstractFloat}=Float64)
   @assert is_n_cube(p) """\n
   Tensor product quadrature rule only for n-cubes.
   """
   @assert length(degrees) == num_dims(p)
-  _tensor_product_legendre(degrees;T=fptype)
+  _tensor_product_legendre(degrees;T=T)
 end
 
-function Quadrature(p::Polytope,name::TensorProduct,degree::Integer;fptype::Type{<:AbstractFloat}=Float64)
+function Quadrature(p::Polytope,name::TensorProduct,degree::Integer;T::Type{<:AbstractFloat}=Float64)
   degrees = ntuple(i->degree,Val(num_dims(p)))
-  Quadrature(p,name,degrees,fptype=fptype)
+  Quadrature(p,name,degrees,T=T)
 end
 
 # Low level constructor

--- a/src/ReferenceFEs/TensorProductQuadratures.jl
+++ b/src/ReferenceFEs/TensorProductQuadratures.jl
@@ -52,11 +52,12 @@ end
 
 function _tensor_product!(quads,coords,weights,cis)
   p = zero(Mutable(eltype(coords)))
+  T = eltype(weights)
   D = length(p)
   lis = LinearIndices(cis)
   for ci in cis
     p[:] = 0.0
-    w = 1.0
+    w = one(T)
     for d in 1:D
       xi = quads[d][1][ci[d]]
       wi = quads[d][2][ci[d]]

--- a/src/ReferenceFEs/TensorProductQuadratures.jl
+++ b/src/ReferenceFEs/TensorProductQuadratures.jl
@@ -20,9 +20,8 @@ end
 
 function _tensor_product_legendre(degrees;T::Type{<:AbstractFloat}=Float64)
     D = length(degrees)
-    # T = Float64
     npoints = [ ceil(Int,(degrees[i]+1.0)/2.0) for i in 1:D ]
-    quads = [ gauss( eltype(Point{D,T}), npoints[i] ) for i in 1:D ]
+    quads = [ gauss(T, npoints[i]) for i in 1:D ]
     for i in 1:D
       quads[i][1] .+= 1;
       quads[i][1] .*= 1.0/2.0

--- a/src/ReferenceFEs/TensorProductQuadratures.jl
+++ b/src/ReferenceFEs/TensorProductQuadratures.jl
@@ -3,24 +3,24 @@ struct TensorProduct <: QuadratureName end
 
 const tensor_product = TensorProduct()
 
-function Quadrature(p::Polytope,::TensorProduct,degrees)
+function Quadrature(p::Polytope,::TensorProduct,degrees;fptype::Type{<:AbstractFloat}=Float64)
   @assert is_n_cube(p) """\n
   Tensor product quadrature rule only for n-cubes.
   """
   @assert length(degrees) == num_dims(p)
-  _tensor_product_legendre(degrees)
+  _tensor_product_legendre(degrees;T=fptype)
 end
 
-function Quadrature(p::Polytope,name::TensorProduct,degree::Integer)
+function Quadrature(p::Polytope,name::TensorProduct,degree::Integer;fptype::Type{<:AbstractFloat}=Float64)
   degrees = ntuple(i->degree,Val(num_dims(p)))
-  Quadrature(p,name,degrees)
+  Quadrature(p,name,degrees,fptype=fptype)
 end
 
 # Low level constructor
 
-function _tensor_product_legendre(degrees)
+function _tensor_product_legendre(degrees;T::Type{<:AbstractFloat}=Float64)
     D = length(degrees)
-    T = Float64
+    # T = Float64
     npoints = [ ceil(Int,(degrees[i]+1.0)/2.0) for i in 1:D ]
     quads = [ gauss( eltype(Point{D,T}), npoints[i] ) for i in 1:D ]
     for i in 1:D

--- a/test/CellDataTests/CellQuadraturesTests.jl
+++ b/test/CellDataTests/CellQuadraturesTests.jl
@@ -61,6 +61,21 @@ s = ∫( x->1 )*quad_N
 @test sum(s) ≈ 6
 @test ∑(s) ≈ 6
 
+quad_N = CellQuadrature(trian_N,degree,fptype=Float32)
+@test eltype(quad_N.cell_point) == Vector{Point{num_dims(trian_N),Float32}}
+@test eltype(quad_N.cell_weight) == Vector{Float32}
+
+s = ∫( ∇(v)⋅∇(u) )*quad_N
+test_array(s,collect(s))
+
+s = ∫(1)*quad_N
+@test sum(s) ≈ 6
+@test ∑(s) ≈ 6
+
+s = ∫( x->1 )*quad_N
+@test sum(s) ≈ 6
+@test ∑(s) ≈ 6
+
 cell_measure = get_cell_measure(trian)
 cell_measure_N = get_cell_measure(trian_N,trian)
 @test length(cell_measure) == num_cells(model)

--- a/test/CellDataTests/CellQuadraturesTests.jl
+++ b/test/CellDataTests/CellQuadraturesTests.jl
@@ -61,7 +61,7 @@ s = ∫( x->1 )*quad_N
 @test sum(s) ≈ 6
 @test ∑(s) ≈ 6
 
-quad_N = CellQuadrature(trian_N,degree,fptype=Float32)
+quad_N = CellQuadrature(trian_N,degree,T=Float32)
 @test eltype(quad_N.cell_point) == Vector{Point{num_dims(trian_N),Float32}}
 @test eltype(quad_N.cell_weight) == Vector{Float32}
 

--- a/test/CellDataTests/DomainContributionsTests.jl
+++ b/test/CellDataTests/DomainContributionsTests.jl
@@ -52,9 +52,9 @@ dΩ = Measure(Ω,quad)
 s = ∫(1)dΩ
 @test sum(s) ≈ 1
 
-dΩ = Measure(Ω,degree,fptype=Float32)
-dΓ = Measure(Γ,degree,fptype=Float32)
-dΛ = Measure(Λ,degree,fptype=Float32)
+dΩ = Measure(Ω,degree,T=Float32)
+dΓ = Measure(Γ,degree,T=Float32)
+dΛ = Measure(Λ,degree,T=Float32)
 
 a = ∫(1)*dΩ + ∫(1)*dΓ
 @test isapprox(sum(a), 5, atol=1e-6)
@@ -70,7 +70,7 @@ a = ∫(jump(u))*dΛ
 a = ∫( (n_Λ.⁺⋅∇(v.⁻))*jump(n_Λ⋅∇(u)) )*dΛ
 @test sum(a) + 1 ≈ 1
 
-quad = Quadrature(duffy,2,fptype=Float32)
+quad = Quadrature(duffy,2,T=Float32)
 dΩ = Measure(Ω,quad)
 s = ∫(1)dΩ
 @test sum(s) ≈ 1

--- a/test/CellDataTests/DomainContributionsTests.jl
+++ b/test/CellDataTests/DomainContributionsTests.jl
@@ -52,4 +52,27 @@ dΩ = Measure(Ω,quad)
 s = ∫(1)dΩ
 @test sum(s) ≈ 1
 
+dΩ = Measure(Ω,degree,fptype=Float32)
+dΓ = Measure(Γ,degree,fptype=Float32)
+dΛ = Measure(Λ,degree,fptype=Float32)
+
+a = ∫(1)*dΩ + ∫(1)*dΓ
+@test isapprox(sum(a), 5, atol=1e-6)
+@test isapprox(sum(2*a), 10, atol=1e-6)
+@test isapprox(sum(a*2), 10, atol=1e-6)
+
+u = CellField(x->2*x[1],Ω)
+v = CellField(x->3*x[2],Ω)
+
+a = ∫(jump(u))*dΛ
+@test sum(a) + 1 ≈ 1
+
+a = ∫( (n_Λ.⁺⋅∇(v.⁻))*jump(n_Λ⋅∇(u)) )*dΛ
+@test sum(a) + 1 ≈ 1
+
+quad = Quadrature(duffy,2,fptype=Float32)
+dΩ = Measure(Ω,quad)
+s = ∫(1)dΩ
+@test sum(s) ≈ 1
+
 end # module

--- a/test/ReferenceFEsTests/DuffyQuadraturesTests.jl
+++ b/test/ReferenceFEsTests/DuffyQuadraturesTests.jl
@@ -7,8 +7,16 @@ degree = 1
 quad = Quadrature(TRI,duffy,degree)
 @test sum(get_weights(quad)) ≈ 0.5
 
+degree = 1
+quad = Quadrature(TRI,duffy,degree,fptype=Float32)
+@test sum(get_weights(quad)) ≈ 0.5
+
 degree = 4
 quad = Quadrature(TET,duffy,degree)
+@test sum(get_weights(quad)) ≈ 0.5*1/3
+
+degree = 4
+quad = Quadrature(TET,duffy,degree,fptype=Float32)
 @test sum(get_weights(quad)) ≈ 0.5*1/3
 
 end # module

--- a/test/ReferenceFEsTests/DuffyQuadraturesTests.jl
+++ b/test/ReferenceFEsTests/DuffyQuadraturesTests.jl
@@ -8,7 +8,7 @@ quad = Quadrature(TRI,duffy,degree)
 @test sum(get_weights(quad)) ≈ 0.5
 
 degree = 1
-quad = Quadrature(TRI,duffy,degree,fptype=Float32)
+quad = Quadrature(TRI,duffy,degree,T=Float32)
 @test sum(get_weights(quad)) ≈ 0.5
 
 degree = 4
@@ -16,7 +16,7 @@ quad = Quadrature(TET,duffy,degree)
 @test sum(get_weights(quad)) ≈ 0.5*1/3
 
 degree = 4
-quad = Quadrature(TET,duffy,degree,fptype=Float32)
+quad = Quadrature(TET,duffy,degree,T=Float32)
 @test sum(get_weights(quad)) ≈ 0.5*1/3
 
 end # module

--- a/test/ReferenceFEsTests/QuadraturesTests.jl
+++ b/test/ReferenceFEsTests/QuadraturesTests.jl
@@ -1,6 +1,6 @@
 module QuadraturesTests
 
-using Test 
+using Test
 using Gridap.Fields
 using Gridap.ReferenceFEs
 using FillArrays
@@ -15,17 +15,17 @@ weights = Fill(1.0,3)
 quad = GenericQuadrature(coords,weights)
 test_quadrature(quad)
 
-# tests with Float32 usage with fptype keyword
+# tests with Float32 usage with T keyword
 
-quad_tensorprod = Quadrature(QUAD,2,fptype=Float32)
+quad_tensorprod = Quadrature(QUAD,2,T=Float32)
 @test eltype(quad_tensorprod.coordinates) == Point{num_dims(QUAD),Float32}
 @test eltype(quad_tensorprod.weights) == Float32
 
-quad_strang = Quadrature(TET,2,fptype=Float32)
+quad_strang = Quadrature(TET,2,T=Float32)
 @test eltype(quad_strang.coordinates) == Point{num_dims(TET),Float32}
 @test eltype(quad_strang.weights) == Float32
 
-quad_duffy = Quadrature(TRI,2,fptype=Float32)
+quad_duffy = Quadrature(TRI,2,T=Float32)
 @test eltype(quad_duffy.coordinates) == Point{num_dims(TRI),Float32}
 @test eltype(quad_duffy.weights) == Float32
 

--- a/test/ReferenceFEsTests/QuadraturesTests.jl
+++ b/test/ReferenceFEsTests/QuadraturesTests.jl
@@ -1,5 +1,6 @@
 module QuadraturesTests
 
+using Test 
 using Gridap.Fields
 using Gridap.ReferenceFEs
 using FillArrays
@@ -13,5 +14,20 @@ coords = Point{2,Float64}[(0.0,0.0),(0.5,0.5),(1.0,1.0)]
 weights = Fill(1.0,3)
 quad = GenericQuadrature(coords,weights)
 test_quadrature(quad)
+
+# tests with Float32 usage with fptype keyword
+
+quad_tensorprod = Quadrature(QUAD,2,fptype=Float32)
+@test eltype(quad_tensorprod.coordinates) == Point{num_dims(QUAD),Float32}
+@test eltype(quad_tensorprod.weights) == Float32
+
+quad_strang = Quadrature(TET,2,fptype=Float32)
+@test eltype(quad_strang.coordinates) == Point{num_dims(TET),Float32}
+@test eltype(quad_strang.weights) == Float32
+
+quad_duffy = Quadrature(TRI,2,fptype=Float32)
+@test eltype(quad_duffy.coordinates) == Point{num_dims(TRI),Float32}
+@test eltype(quad_duffy.weights) == Float32
+
 
 end # module

--- a/test/ReferenceFEsTests/TensorProductQuadraturesTests.jl
+++ b/test/ReferenceFEsTests/TensorProductQuadraturesTests.jl
@@ -9,7 +9,7 @@ quad = Quadrature(QUAD,tensor_product,degrees)
 test_quadrature(quad)
 @test sum(get_weights(quad)) ≈ 1
 
-quad = Quadrature(QUAD,tensor_product,degrees,fptype=Float32)
+quad = Quadrature(QUAD,tensor_product,degrees,T=Float32)
 test_quadrature(quad)
 @test sum(get_weights(quad)) ≈ 1
 
@@ -19,7 +19,7 @@ quad = Quadrature(QUAD,tensor_product,degree)
 test_quadrature(quad)
 @test sum(get_weights(quad)) ≈ 1
 
-quad = Quadrature(QUAD,tensor_product,degree,fptype=Float32)
+quad = Quadrature(QUAD,tensor_product,degree,T=Float32)
 test_quadrature(quad)
 @test sum(get_weights(quad)) ≈ 1
 

--- a/test/ReferenceFEsTests/TensorProductQuadraturesTests.jl
+++ b/test/ReferenceFEsTests/TensorProductQuadraturesTests.jl
@@ -9,9 +9,17 @@ quad = Quadrature(QUAD,tensor_product,degrees)
 test_quadrature(quad)
 @test sum(get_weights(quad)) ≈ 1
 
+quad = Quadrature(QUAD,tensor_product,degrees,fptype=Float32)
+test_quadrature(quad)
+@test sum(get_weights(quad)) ≈ 1
+
 D = 2
 degree = 3
 quad = Quadrature(QUAD,tensor_product,degree)
+test_quadrature(quad)
+@test sum(get_weights(quad)) ≈ 1
+
+quad = Quadrature(QUAD,tensor_product,degree,fptype=Float32)
 test_quadrature(quad)
 @test sum(get_weights(quad)) ≈ 1
 


### PR DESCRIPTION
Hi @amartinhuertas and @fverdugo, I have added support to include a keyword argument `T` into `Measure`, `CellQuadrature` and `Quadrature`, to perform numerical integration in the desired floating-point precision, in particular, `Float32` usage. Tests have been added to for checks with `Float32` option for all the effected modules.

This partially resolves the issue https://github.com/gridap/Gridap.jl/issues/789 for the quadrature part. The setup of `FESpace` at places seems hard-coded in `Float64`, and the floating-point type is not being taken from `model` and `reffe` constructed using `Float32` precisions, which I leave for later. 

This doesn't break the high-level API, as the optional `kwarg` `T` defaults to `Float64`. The usage is as follows:
```julia
dΩ = Measure(Ω,2,T=Float32)
quad_strang = Quadrature(TET,2,T=Float32)
```

Would be happy to know to comments and suggestions for changes and improvements. 