### PR TITLE
GeneralizedAlpha for 2nd order ODE 

### DIFF
--- a/src/ODEs/ODETools/GeneralizedAlpha.jl
+++ b/src/ODEs/ODETools/GeneralizedAlpha.jl
@@ -47,7 +47,60 @@ function solve_step!(
 
 end
 
+
+function solve_step!(
+  x1::NTuple{3,AbstractVector},
+  solver::GeneralizedAlpha,
+  op::ODEOperator,
+  x0::NTuple{3,AbstractVector},
+  t0::Real,
+  cache) # -> (uF,tF)
+
+  dt = solver.dt
+  ρ∞ = solver.ρ∞
+  αf = ρ∞/(ρ∞ + 1.0)
+  αm = (2*ρ∞ - 1.0)/(ρ∞ + 1.0)
+  γ = 0.5 - αm + αf
+  β = 0.25*((1.0 - αm + αf)^2)
+  tαf = t0 + (1.0-αf)*dt
+  u0, v0, a0 = x0
+  u1, v1, a1 = x1
+
+  if cache === nothing
+    generalizedAlphaDtt_cache = allocate_cache(op,v0,a0)
+    nl_cache = nothing
+  else
+    generalizedAlphaDtt_cache, nl_cache = cache
+  end
+
+  (v0, a0, ode_cache) = generalizedAlphaDtt_cache
+  ode_cache = update_cache!(ode_cache,op,tαf)
+  nlop = GeneralizedAlphaDttNonlinearOperator(op,tαf,dt,αm,αf,γ,β,(u0,v0,a0),generalizedAlphaDtt_cache)
+  nl_cache = solve!(u1,solver.nls,nlop,nl_cache)
+  
+
+  u1 = 1.0 / (1.0 - αf) * u1 - 
+    αf / (1.0 - αf) * u0
+
+  v1 = γ / (β*dt) * (u1 - u0) - 
+    (γ - β) / β * v0 - 
+    (γ - 2.0 * β) / (2.0 * β) * dt * a0
+  
+  a1 = 1.0 / (β * dt * dt) * (u1 - u0) - 
+    1.0 / (β * dt) * v0 - 
+    (1.0 - 2.0 * β) / (2.0 * β) * a0
+
+  cache = (generalizedAlphaDtt_cache, nl_cache)
+  x1 = (u1,v1,a1)
+  t1 = t0+dt
+
+  return (x1,t1,cache)
+
+end
+
+
 """
+Generalized-α 1st order ODE solver
 Nonlinear operator that represents the Generalized-α method nonlinear operator at a
 given time step, i.e., A(t_αf,u_n+αf,v_n+αm)
 """
@@ -91,6 +144,87 @@ function allocate_jacobian(op::GeneralizedAlphaNonlinearOperator,x::AbstractVect
 end
 
 function zero_initial_guess(op::GeneralizedAlphaNonlinearOperator)
+  x0 = similar(op.u0)
+  fill!(x0,zero(eltype(x0)))
+  x0
+end
+
+
+"""
+Generalized-α 2nd order ODE solver
+Nonlinear operator that represents the Generalized-α method nonlinear operator at a
+given time step, i.e., A(t_(n+1-αf),u_(n+1-αf),v_(n+1-αf),a_(n+1-αm))
+"""
+
+struct GeneralizedAlphaDttNonlinearOperator <: NonlinearOperator
+  odeop::ODEOperator
+  tαf::Float64
+  dt::Float64
+  αm::Float64
+  αf::Float64
+  γ::Float64
+  β::Float64
+  x0::NTuple{3,AbstractVector}
+  ode_cache
+end
+
+
+function residual!(b::AbstractVector,op::GeneralizedAlphaDttNonlinearOperator,x::AbstractVector)
+  uαf = x
+  u0, v0, a0 = op.x0
+  vαf, aαm, cache = op.ode_cache  
+  
+  vαf = (op.γ) / (op.β * op.dt) * (uαf - u0) + 
+    (op.αf - 1.0) * (op.γ - op.β) / op.β * v0 + 
+    (op.αf - 1.0) * (op.γ - 2.0*op.β) / (2.0 * op.β) * op.dt * a0 +
+    op.αf * v0
+  
+  aαm = (1.0 - op.αm) / (1.0 - op.αf) / (op.β * op.dt * op.dt) * (uαf - u0) + 
+    (op.αm - 1.0) / (op.β * op.dt) * v0 + 
+    (op.αm - 1.0) * (1.0 - 2.0*op.β) / (2.0 * op.β) * a0 + 
+    op.αm * a0
+
+  residual!(b,op.odeop,op.tαf,(uαf,vαf,aαm),cache)
+end
+
+
+function jacobian!(A::AbstractMatrix,op::GeneralizedAlphaDttNonlinearOperator,x::AbstractVector)
+  uαf = x
+  u0, v0, a0 = op.x0
+  vαf, aαm, cache = op.ode_cache  
+  
+  vαf = (op.γ) / (op.β * op.dt) * (uαf - u0) + 
+    (op.αf - 1.0) * (op.γ - op.β) / op.β * v0 + 
+    (op.αf - 1.0) * (op.γ - 2.0*op.β) / (2.0 * op.β) * op.dt * a0 +
+    op.αf * v0
+  
+  aαm = (1.0 - op.αm) / (1.0 - op.αf) / (op.β * op.dt * op.dt) * (uαf - u0) + 
+    (op.αm - 1.0) / (op.β * op.dt) * v0 + 
+    (op.αm - 1.0) * (1.0 - 2.0*op.β) / (2.0 * op.β) * a0 + 
+    op.αm * a0
+  
+  z = zero(eltype(A))
+  fillstored!(A,z)
+  jacobians!(A,op.odeop,op.tαf,(uαf,vαf,aαm),
+    (1.0, op.γ/(op.β * op.dt), 
+      (1.0 - op.αm) / (1.0 - op.αf) / (op.β * op.dt * op.dt)),
+    cache)
+end
+
+
+function allocate_residual(op::GeneralizedAlphaDttNonlinearOperator,x::AbstractVector)
+  vαf, aαm, cache = op.ode_cache
+  allocate_residual(op.odeop,x,cache)
+end
+
+
+function allocate_jacobian(op::GeneralizedAlphaDttNonlinearOperator,x::AbstractVector)
+  vαf, aαm, cache = op.ode_cache
+  allocate_jacobian(op.odeop,x,cache)
+end
+
+
+function zero_initial_guess(op::GeneralizedAlphaDttNonlinearOperator)
   x0 = similar(op.u0)
   fill!(x0,zero(eltype(x0)))
   x0

--- a/test/ODEsTests/ODEsTests/ODESolversTests.jl
+++ b/test/ODEsTests/ODEsTests/ODESolversTests.jl
@@ -195,7 +195,7 @@ ufθ, tf, cache = solve_step!(ufθ,odesolθ,op,u0,t0,nothing)
 @test all(vf.≈ 1/(γ*dt) * (ufα-u0) + (1-1/γ)*v0)
 
 
-## GeneralizedAlpha ∂tt test
+# GeneralizedAlpha ∂tt test
 println("GeneralizedAlpha ∂tt test")
 ufα = nothing; vfα = nothing; afα = nothing
 u0 = ones(2)*2
@@ -205,7 +205,7 @@ ls = LUSolver()
 β = 0.25
 ρ∞ = 1.0 # Equivalent to Newmark(0.5, 0.25)
 odesolN = Newmark(ls,dt,γ,β)
-odesolα = GeneralizedAlphaDtt(ls, dt, ρ∞)
+odesolα = GeneralizedAlpha(ls, dt, ρ∞)
 ufN = copy(u0)
 ufα = copy(u0)
 v0 = ones(2)*1.0

--- a/test/ODEsTests/ODEsTests/ODESolversTests.jl
+++ b/test/ODEsTests/ODEsTests/ODESolversTests.jl
@@ -194,4 +194,34 @@ ufθ, tf, cache = solve_step!(ufθ,odesolθ,op,u0,t0,nothing)
 @test all(ufα.≈ufθ)
 @test all(vf.≈ 1/(γ*dt) * (ufα-u0) + (1-1/γ)*v0)
 
+
+## GeneralizedAlpha ∂tt test
+println("GeneralizedAlpha ∂tt test")
+ufα = nothing; vfα = nothing; afα = nothing
+u0 = ones(2)*2
+op = ODEOperatorMock{Float64,Nonlinear}(0.0,0.0,0.0,2)
+ls = LUSolver()
+γ = 0.5
+β = 0.25
+ρ∞ = 1.0 # Equivalent to Newmark(0.5, 0.25)
+odesolN = Newmark(ls,dt,γ,β)
+odesolα = GeneralizedAlphaDtt(ls, dt, ρ∞)
+ufN = copy(u0)
+ufα = copy(u0)
+v0 = ones(2)*1.0
+a0 = 0.0*ones(2)
+ufN .= 1.0
+ufα .= 1.0
+println(t0,u0,v0,a0)
+(ufN, vfN, afN), tfN, cache = 
+    solve_step!((ufN,v0,a0),odesolN,op,(u0,v0,a0),t0,nothing)
+(ufα, vfα, afα), tfα, cache = 
+    solve_step!((ufα,v0,a0),odesolα,op,(u0,v0,a0),t0,nothing)
+println(tfN, ufN, vfN, afN)
+println(tfα, ufα, vfα, afα)
+@test tfα==tfN
+@test sqrt(sum(abs2.(ufα - ufN))) < 1.0e-10
+@test sqrt(sum(abs2.(vfα - vfN))) < 1.0e-10
+@test sqrt(sum(abs2.(afα - afN))) < 1.0e-10
+
 # end #module


### PR DESCRIPTION
Added GeneralizedAlpha methods for 2nd order ODE in GeneralizedAlpha.jl. 
Added the test in ODESolversTests.jl. 
The method is used in solving the Generalised Wave Continuity Equation.