### PR TITLE
Positive simplexify

### DIFF
--- a/src/Geometry/DiscreteModels.jl
+++ b/src/Geometry/DiscreteModels.jl
@@ -375,9 +375,9 @@ end
 """
     simplexify(model::DiscreteModel)
 """
-function simplexify(model::DiscreteModel)
+function simplexify(model::DiscreteModel;kwargs...)
   umodel = UnstructuredDiscreteModel(model)
-  simplexify(umodel)
+  simplexify(umodel;kwargs...)
 end
 
 function ReferenceFE(model::DiscreteModel,args...;kwargs...)

--- a/src/Geometry/Grids.jl
+++ b/src/Geometry/Grids.jl
@@ -405,8 +405,8 @@ function Grid(::Type{ReferenceFE{d}},p::Polytope) where d
 end
 
 """
-    simplexify(grid::Grid)
+    simplexify(grid::Grid;kwargs...)
 """
-function simplexify(grid::Grid)
-  simplexify(UnstructuredGrid(grid))
+function simplexify(grid::Grid;kwargs...)
+  simplexify(UnstructuredGrid(grid);kwargs...)
 end

--- a/src/Geometry/UnstructuredDiscreteModels.jl
+++ b/src/Geometry/UnstructuredDiscreteModels.jl
@@ -115,7 +115,7 @@ function from_dict(T::Type{UnstructuredDiscreteModel},dict::Dict{Symbol,Any})
   UnstructuredDiscreteModel(grid,topo,labeling)
 end
 
-function simplexify(model::UnstructuredDiscreteModel)
+function simplexify(model::UnstructuredDiscreteModel;kwargs...)
   grid = get_grid(model)
   grid_topology = get_grid_topology(model)
   cell_vertices = get_cell_vertices(grid_topology)
@@ -123,7 +123,7 @@ function simplexify(model::UnstructuredDiscreteModel)
   nnodes = num_nodes(grid)
   nvertices = num_vertices(grid_topology)
   labels = get_face_labeling(model)
-  tgrid = simplexify(grid)
+  tgrid = simplexify(grid;kwargs...)
   cell_ctype = get_cell_type(grid)
   tcell_nodes = get_cell_node_ids(tgrid)
   tcell_tctype = get_cell_type(tgrid)
@@ -147,7 +147,7 @@ function simplexify(model::UnstructuredDiscreteModel)
     tctype_ltvertex_ltnode,
     tcell_tctype)
   tgrid_topology = GridTopology(tgrid, tcell_vertices, vertex_node)
-  tfacelabels = _generate_tfacelabels(grid_topology, tgrid_topology, reffes, labels)
+  tfacelabels = _generate_tfacelabels(grid_topology, tgrid_topology, reffes, labels; kwargs... )
   UnstructuredDiscreteModel(tgrid,tgrid_topology,tfacelabels)
 end
 
@@ -212,12 +212,12 @@ function _preapre_tvertices(
   tcell_vertices, vertex_node
 end
 
-function _generate_tfacelabels(grid_topology, tgrid_topology, reffes, facelabels)
+function _generate_tfacelabels(grid_topology, tgrid_topology, reffes, facelabels; kwargs... )
 
   @notimplementedif length(reffes) != 1
   reffe = first(reffes)
   p = get_polytope(reffe)
-  ltcell_to_lnodes, simplex = simplexify(p)
+  ltcell_to_lnodes, simplex = simplexify(p;kwargs...)
 
   D = num_cell_dims(grid_topology)
 

--- a/src/Geometry/UnstructuredGrids.jl
+++ b/src/Geometry/UnstructuredGrids.jl
@@ -205,14 +205,14 @@ function from_dict(::Type{UnstructuredGrid},dict::Dict{Symbol,Any})
     O ? Oriented() : NonOriented())
 end
 
-function simplexify(grid::UnstructuredGrid)
+function simplexify(grid::UnstructuredGrid;kwargs...)
   reffes = get_reffes(grid)
   @notimplementedif length(reffes) != 1
   reffe = first(reffes)
   order = 1
   @notimplementedif get_order(reffe) != order
   p = get_polytope(reffe)
-  ltcell_to_lpoints, simplex = simplexify(p)
+  ltcell_to_lpoints, simplex = simplexify(p;kwargs...)
   cell_to_points = get_cell_node_ids(grid)
   tcell_to_points = _refine_grid_connectivity(cell_to_points, ltcell_to_lpoints)
   ctype_to_reffe = [LagrangianRefFE(Float64,simplex,order),]

--- a/src/ReferenceFEs/ExtrusionPolytopes.jl
+++ b/src/ReferenceFEs/ExtrusionPolytopes.jl
@@ -225,17 +225,18 @@ function is_n_cube(p::ExtrusionPolytope{1})
   true
 end
 
-function simplexify(p::ExtrusionPolytope{0})
+function simplexify(p::ExtrusionPolytope{0};kwargs...)
   [[1,],], VERTEX
 end
 
-function simplexify(p::ExtrusionPolytope{1})
+function simplexify(p::ExtrusionPolytope{1};kwargs...)
   [[1,2],], Polytope(TET_AXIS)
 end
 
-function simplexify(p::ExtrusionPolytope{2})
+function simplexify(p::ExtrusionPolytope{2};oriented=false)
   if p == QUAD
-    ([[1,2,3],[2,3,4]], TRI)
+    simplices = simplexify_hypercube(2,oriented)
+    (simplices, TRI)
   elseif p == TRI
     ([[1,2,3],], TRI)
   else
@@ -243,11 +244,9 @@ function simplexify(p::ExtrusionPolytope{2})
   end
 end
 
-function simplexify(p::ExtrusionPolytope{3})
+function simplexify(p::ExtrusionPolytope{3};oriented=false)
   if p == HEX
-    simplices = [
-      [1,2,3,7], [1,2,5,7], [2,3,4,7],
-      [2,4,7,8], [2,5,6,7], [2,6,7,8]]
+    simplices = simplexify_hypercube(3,oriented)
     (simplices, TET)
   elseif p == TET
     simplices = [[1,2,3,4],]
@@ -257,12 +256,13 @@ function simplexify(p::ExtrusionPolytope{3})
   end
 end
 
-function simplexify(p::ExtrusionPolytope{D}) where {D}
+function simplexify(p::ExtrusionPolytope{D};oriented=false) where {D}
   # This function works for all dimensions. It could replace the
   # special cases above, but this might change the shape and order of
   # simplices.
-  SD = Polytope(ntuple(d->TET_AXIS, D))
-  QD = Polytope(ntuple(d->HEX_AXIS, D))
+  @notimplementedif oriented
+  SD = Polytope(ntuple(d->TET_AXIS, Val{D}() ))
+  QD = Polytope(ntuple(d->HEX_AXIS, Val{D}() ))
   if p == QD
     simplices = simplexify_hypercube(D)
     (simplices, SD)
@@ -271,6 +271,37 @@ function simplexify(p::ExtrusionPolytope{D}) where {D}
     (simplices, SD)
   else
      @notimplemented
+  end
+end
+
+function simplexify_hypercube(dim::Integer,oriented::Bool)
+  if oriented
+    oriented_simplexify_hypercube(dim)
+  else
+    sorted_simplexify_hypercube(dim)
+  end
+end
+
+function sorted_simplexify_hypercube(dim::Integer)
+  if dim == 2
+    [[1,2,3],[2,3,4]]
+  elseif dim == 3
+    [[1,2,3,7], [1,2,5,7], [2,3,4,7],
+    [2,4,7,8], [2,5,6,7], [2,6,7,8]]
+  else
+    @show dim
+    @notimplemented
+  end
+end
+
+function oriented_simplexify_hypercube(dim::Integer)
+  if dim == 2
+    [[1,2,3],[2,4,3]]
+  elseif dim == 3
+    [[1,2,3,7], [1,5,2,7], [2,4,3,7],
+    [2,4,7,8], [2,5,6,7], [2,7,6,8]]
+  else
+    @notimplemented
   end
 end
 

--- a/src/ReferenceFEs/ExtrusionPolytopes.jl
+++ b/src/ReferenceFEs/ExtrusionPolytopes.jl
@@ -233,9 +233,9 @@ function simplexify(p::ExtrusionPolytope{1};kwargs...)
   [[1,2],], Polytope(TET_AXIS)
 end
 
-function simplexify(p::ExtrusionPolytope{2};oriented=false)
+function simplexify(p::ExtrusionPolytope{2};positive=false)
   if p == QUAD
-    simplices = simplexify_hypercube(2,oriented)
+    simplices = simplexify_hypercube(2,positive)
     (simplices, TRI)
   elseif p == TRI
     ([[1,2,3],], TRI)
@@ -244,9 +244,9 @@ function simplexify(p::ExtrusionPolytope{2};oriented=false)
   end
 end
 
-function simplexify(p::ExtrusionPolytope{3};oriented=false)
+function simplexify(p::ExtrusionPolytope{3};positive=false)
   if p == HEX
-    simplices = simplexify_hypercube(3,oriented)
+    simplices = simplexify_hypercube(3,positive)
     (simplices, TET)
   elseif p == TET
     simplices = [[1,2,3,4],]
@@ -256,11 +256,11 @@ function simplexify(p::ExtrusionPolytope{3};oriented=false)
   end
 end
 
-function simplexify(p::ExtrusionPolytope{D};oriented=false) where {D}
+function simplexify(p::ExtrusionPolytope{D};positive=false) where {D}
   # This function works for all dimensions. It could replace the
   # special cases above, but this might change the shape and order of
   # simplices.
-  @notimplementedif oriented
+  @notimplementedif positive
   SD = Polytope(ntuple(d->TET_AXIS, Val{D}() ))
   QD = Polytope(ntuple(d->HEX_AXIS, Val{D}() ))
   if p == QD
@@ -274,27 +274,26 @@ function simplexify(p::ExtrusionPolytope{D};oriented=false) where {D}
   end
 end
 
-function simplexify_hypercube(dim::Integer,oriented::Bool)
-  if oriented
-    oriented_simplexify_hypercube(dim)
+function simplexify_hypercube(dim::Integer,positive::Bool)
+  if positive
+    positive_simplexify_hypercube(dim)
   else
-    sorted_simplexify_hypercube(dim)
+    oriented_simplexify_hypercube(dim)
   end
 end
 
-function sorted_simplexify_hypercube(dim::Integer)
+function oriented_simplexify_hypercube(dim::Integer)
   if dim == 2
     [[1,2,3],[2,3,4]]
   elseif dim == 3
     [[1,2,3,7], [1,2,5,7], [2,3,4,7],
     [2,4,7,8], [2,5,6,7], [2,6,7,8]]
   else
-    @show dim
     @notimplemented
   end
 end
 
-function oriented_simplexify_hypercube(dim::Integer)
+function positive_simplexify_hypercube(dim::Integer)
   if dim == 2
     [[1,2,3],[2,4,3]]
   elseif dim == 3

--- a/src/ReferenceFEs/Polytopes.jl
+++ b/src/ReferenceFEs/Polytopes.jl
@@ -236,7 +236,7 @@ end
 """
     simplexify(p::Polytope) -> Tuple{Vector{Vector{Int}},Polytope}
 """
-function simplexify(p::Polytope)
+function simplexify(p::Polytope;kwargs...)
   @abstractmethod
 end
 

--- a/test/GeometryTests/CartesianGridsTests.jl
+++ b/test/GeometryTests/CartesianGridsTests.jl
@@ -6,6 +6,7 @@ using Test
 using Gridap.Helpers
 using Gridap.Arrays
 using Gridap.TensorValues
+using Gridap.TensorValues: det
 using Gridap.Fields
 using Gridap.Geometry
 using Gridap.ReferenceFEs
@@ -102,8 +103,13 @@ grid = CartesianGrid(domain,partition)
 tgrid = simplexify(grid)
 test_grid(tgrid)
 
-otgrid = simplexify(grid,oriented=true)
-test_grid(otgrid)
+ptgrid = simplexify(grid,positive=true)
+test_grid(ptgrid)
+
+Jtk = lazy_map(∇,get_cell_map(ptgrid))
+X0k = lazy_map(first,get_cell_coordinates(ptgrid))
+Jt0k = lazy_map(evaluate,Jtk,X0k)
+@test all(>(0),lazy_map(det,Jt0k))
 
 grid = compute_reference_grid(HEX8,4)
 test_grid(grid)

--- a/test/GeometryTests/CartesianGridsTests.jl
+++ b/test/GeometryTests/CartesianGridsTests.jl
@@ -97,6 +97,14 @@ test_array(mx,reshape(r,size(map)))
 test_array(∇mx,reshape(∇r,size(map)))
 @test isa(∇mx,Fill)
 
+ptgrid = simplexify(grid,positive=true)
+test_grid(ptgrid)
+
+Jtk = lazy_map(∇,get_cell_map(ptgrid))
+X0k = lazy_map(first,get_cell_coordinates(ptgrid))
+Jt0k = lazy_map(evaluate,Jtk,X0k)
+@test all(>(0),lazy_map(det,Jt0k))
+
 domain = (0,1,0,1,0,1)
 partition = (2,2,2)
 grid = CartesianGrid(domain,partition)

--- a/test/GeometryTests/CartesianGridsTests.jl
+++ b/test/GeometryTests/CartesianGridsTests.jl
@@ -102,6 +102,9 @@ grid = CartesianGrid(domain,partition)
 tgrid = simplexify(grid)
 test_grid(tgrid)
 
+otgrid = simplexify(grid,oriented=true)
+test_grid(otgrid)
+
 grid = compute_reference_grid(HEX8,4)
 test_grid(grid)
 

--- a/test/GeometryTests/DiscreteModelsTests.jl
+++ b/test/GeometryTests/DiscreteModelsTests.jl
@@ -85,6 +85,14 @@ model = CartesianDiscreteModel(domain,partition)
 tmodel = simplexify(model)
 test_discrete_model(tmodel)
 
+otmodel = simplexify(model,oriented=true)
+test_discrete_model(otmodel)
+
+Jk = lazy_map(∇,get_cell_map(otmodel))
+J0k = lazy_map(evaluate,Jk,Fill(Point(0,0,0),num_cells(otmodel)))
+oriented = lazy_map(isone∘sign∘det,J0k)
+@test all(oriented)
+
 model2 = DiscreteModel(grid,topo,labeling)
 test_discrete_model(model2)
 

--- a/test/GeometryTests/DiscreteModelsTests.jl
+++ b/test/GeometryTests/DiscreteModelsTests.jl
@@ -4,6 +4,7 @@ using Test
 using Gridap.Arrays
 using Gridap.Fields
 using Gridap.ReferenceFEs
+using Gridap.TensorValues: det
 using Gridap.Geometry
 using Gridap.Geometry: DiscreteModelMock
 using Gridap.Io
@@ -85,8 +86,13 @@ model = CartesianDiscreteModel(domain,partition)
 tmodel = simplexify(model)
 test_discrete_model(tmodel)
 
-otmodel = simplexify(model,oriented=true)
-test_discrete_model(otmodel)
+ptmodel = simplexify(model,positive=true)
+test_discrete_model(ptmodel)
+
+Jtk = lazy_map(∇,get_cell_map(ptmodel))
+X0k = lazy_map(first,get_cell_coordinates(ptmodel))
+Jt0k = lazy_map(evaluate,Jtk,X0k)
+@test all(>(0),lazy_map(det,Jt0k))
 
 model2 = DiscreteModel(grid,topo,labeling)
 test_discrete_model(model2)

--- a/test/GeometryTests/DiscreteModelsTests.jl
+++ b/test/GeometryTests/DiscreteModelsTests.jl
@@ -88,11 +88,6 @@ test_discrete_model(tmodel)
 otmodel = simplexify(model,oriented=true)
 test_discrete_model(otmodel)
 
-Jk = lazy_map(∇,get_cell_map(otmodel))
-J0k = lazy_map(evaluate,Jk,Fill(Point(0,0,0),num_cells(otmodel)))
-oriented = lazy_map(isone∘sign∘det,J0k)
-@test all(oriented)
-
 model2 = DiscreteModel(grid,topo,labeling)
 test_discrete_model(model2)
 

--- a/test/ReferenceFEsTests/ExtrusionPolytopesTests.jl
+++ b/test/ReferenceFEsTests/ExtrusionPolytopesTests.jl
@@ -156,6 +156,18 @@ for dim in 0:5
     @test p == SD
     @test is_simplex(p)
 
+    if dim <= 3
+      vss,p = simplexify(QD,oriented=true)
+      @test length(vss) == factorial(dim)
+      for vs in vss
+          @test allunique(vs)
+          @test all(1 ≤ v ≤ 2^dim for v in vs)
+      end
+      @test allunique(vss)
+      @test p == SD
+      @test is_simplex(p)
+    end
+
     vss,p = simplexify(SD)
     @test length(vss) == 1
     for vs in vss

--- a/test/ReferenceFEsTests/ExtrusionPolytopesTests.jl
+++ b/test/ReferenceFEsTests/ExtrusionPolytopesTests.jl
@@ -157,7 +157,7 @@ for dim in 0:5
     @test is_simplex(p)
 
     if dim <= 3
-      vss,p = simplexify(QD,oriented=true)
+      vss,p = simplexify(QD,positive=true)
       @test length(vss) == factorial(dim)
       for vs in vss
           @test allunique(vs)


### PR DESCRIPTION
Extension of `simplexify()` methods to return a simplex partition with **positive Jacobians** when keyword `positive=true`.

The following methods allow `positive` keyword:
```
simplexify(grid::Grid;positive=true)
simplexify(model::DiscreteModel;positive=true)
simplexify(polytope::ExtrusionPolytope;positive=true)
```

Positive simplexify is only implemented for $n$-cubes with `0 < num_dims <= 3`

Example of usage:
https://github.com/gridap/Gridap.jl/blob/d838369d26fde7805d7aca0237d3451d4a6d2a8c/test/GeometryTests/CartesianGridsTests.jl#L114

