### PR TITLE
Add `ascii` and `append` kwargs to writevtk interface

### DIFF
--- a/src/Visualization/Vtk.jl
+++ b/src/Visualization/Vtk.jl
@@ -1,20 +1,22 @@
 """
 """
-function writevtk(args...;kwargs...)
+function writevtk(args...;ascii=false,append=!ascii,kwargs...)
   map(visualization_data(args...;kwargs...)) do visdata
     write_vtk_file(
-    visdata.grid,visdata.filebase,celldata=visdata.celldata,nodaldata=visdata.nodaldata)
+      visdata.grid,visdata.filebase;
+      celldata=visdata.celldata,nodaldata=visdata.nodaldata,ascii,append)
   end
 end
 
 """
 """
-function createvtk(args...;kwargs...)
+function createvtk(args...;ascii=false,append=!ascii,kwargs...)
   v = visualization_data(args...;kwargs...)
   @notimplementedif length(v) != 1
   visdata = first(v)
   create_vtk_file(
-    visdata.grid,visdata.filebase,celldata=visdata.celldata,nodaldata=visdata.nodaldata)
+    visdata.grid,visdata.filebase;
+    celldata=visdata.celldata,nodaldata=visdata.nodaldata,ascii,append)
 end
 
 """
@@ -49,8 +51,8 @@ Low level entry point to vtk. Other vtk-related routines in Gridap eventually ca
 
 """
 function write_vtk_file(
-  trian::Grid, filebase; celldata=Dict(), nodaldata=Dict())
-  vtkfile = create_vtk_file(trian, filebase, celldata=celldata, nodaldata=nodaldata)
+  trian::Grid, filebase; celldata=Dict(), nodaldata=Dict(), kwargs... )
+  vtkfile = create_vtk_file(trian, filebase; celldata, nodaldata, kwargs...)
   outfiles = vtk_save(vtkfile)
 end
 
@@ -67,11 +69,12 @@ This function only creates the vtkFile, without writing to disk.
 
 """
 function create_vtk_file(
-  trian::Grid, filebase; celldata=Dict(), nodaldata=Dict())
+  trian::Grid, filebase;
+  celldata=Dict(), nodaldata=Dict(), ascii=false, append=!ascii)
 
   points = _vtkpoints(trian)
   cells = _vtkcells(trian)
-  vtkfile = vtk_grid(filebase, points, cells, compress=false)
+  vtkfile = vtk_grid(filebase, points, cells; compress=false, ascii, append)
 
   if num_cells(trian)>0
     for (k,v) in celldata
@@ -87,12 +90,13 @@ end
 
 function create_pvtk_file(
   trian::Grid, filebase;
-  part, nparts, ismain=(part==1), celldata=Dict(), nodaldata=Dict())
+  part, nparts, ismain=(part==1), celldata=Dict(), nodaldata=Dict(),
+  ascii=false, append=!ascii)
 
   points = _vtkpoints(trian)
   cells = _vtkcells(trian)
-  vtkfile = pvtk_grid(filebase, points, cells, compress=false;
-                      part=part, nparts=nparts, ismain=ismain)
+  vtkfile = pvtk_grid(filebase, points, cells;
+                      compress=false, part, nparts, ismain, ascii, append)
 
   if num_cells(trian) > 0
     for (k, v) in celldata

--- a/test/VisualizationTests/VtkTests.jl
+++ b/test/VisualizationTests/VtkTests.jl
@@ -36,9 +36,25 @@ pvtk = Visualization.create_pvtk_file(
   celldata=["cellid"=>cell_ids,"centers"=>cell_center])
 vtk_save(pvtk)
 
+write_vtk_file(
+  trian,f,
+  nodaldata=["nodeid"=>node_ids],
+  celldata=["cellid"=>cell_ids,"centers"=>cell_center],
+  ascii=true)
+
+pvtk = Visualization.create_pvtk_file(
+  trian,f; part=1, nparts=1,
+  nodaldata=["nodeid"=>node_ids],
+  celldata=["cellid"=>cell_ids,"centers"=>cell_center],
+  ascii=true)
+vtk_save(pvtk)
+
 reffe = LagrangianRefFE(VectorValue{3,Float64},WEDGE,(3,3,4))
 f = joinpath(d,"reffe")
 writevtk(reffe,f)
+
+f = joinpath(d,"reffe_ascii")
+writevtk(reffe,f,ascii=true)
 
 reffe = LagrangianRefFE(VectorValue{2,Float64},QUAD,(2,0))
 f = joinpath(d,"reffe")
@@ -116,6 +132,17 @@ paraview_collection(f) do pvd
     for i in 1:10
         pvd[Float64(i)] = createvtk(trian, f*"_$i", celldata=["rnd"=>rand(num_cells(trian))], cellfields=["cf" => cf])
         pvd[Float64(10+i)] = createvtk(x,f*"_$(10+i)",celldata=["cellid" => collect(1:num_cells(trian))], nodaldata = ["x" => x])
+    end
+    vtk_save(pvd)
+end
+
+model = DiscreteModelMock()
+trian = Triangulation(model)
+f = joinpath(d,"collection_ascii")
+paraview_collection(f) do pvd
+    for i in 1:10
+        pvd[Float64(i)] = createvtk(trian, f*"_$i", celldata=["rnd"=>rand(num_cells(trian))], cellfields=["cf" => cf],ascii=true)
+        pvd[Float64(10+i)] = createvtk(x,f*"_$(10+i)",celldata=["cellid" => collect(1:num_cells(trian))], nodaldata = ["x" => x],ascii=true)
     end
     vtk_save(pvd)
 end


### PR DESCRIPTION
Added `ascii = false, append = ! ascii` Bool kwargs to writevtk.

The defaults are set according to `WriteVTK.jl` manual:

https://jipolanco.github.io/WriteVTK.jl/v1.16/grids/syntax/

As `ascii` is not compatible with `append` the default append is set to `! ascii`

