### PR TITLE
Pseudoinverse to enable evaluate() at Boundary.

### DIFF
--- a/src/Fields/AffineMaps.jl
+++ b/src/Fields/AffineMaps.jl
@@ -99,7 +99,7 @@ end
 function inverse_map(f::AffineMap)
   Jt = f.gradient
   y0 = f.origin
-  invJt = inv(Jt)
+  invJt = pinvJt(Jt)
   x0 = -y0⋅invJt
   AffineMap(invJt,x0)
 end

--- a/test/GridapTests/issue_873.jl
+++ b/test/GridapTests/issue_873.jl
@@ -1,0 +1,43 @@
+module Issue873
+
+using Gridap
+
+# Create a Cartesian grid
+domain =  (0, 1, 0, 0.5)
+partition = (10, 5)
+model = CartesianDiscreteModel(domain, partition)
+
+# Assign the label "surface" to the entity 3,4 and 6 
+# (top corners and top side)
+labels_Ω = get_face_labeling(model)
+add_tag_from_tags!(labels_Ω,"surface",[3,4,6])   
+
+# Triangulations
+Ω = Interior(model) 
+Γ = Boundary(model,tags="surface") 
+
+# Define a mock function
+fa(x) = x[1] + x[2]*2
+
+# Interpolate the mock function onto the "interior"
+reffe = ReferenceFE(lagrangian, Float64, 2)
+fΩ = interpolate_everywhere(fa, FESpace(Ω,reffe))
+
+# "evaluate" at an arbitrary point within the "interior" FESpace
+@show fΩ( Point(0.52, 0.5) ) 
+
+# Interpolate the mock function onto the "surface"
+fΓ = interpolate_everywhere(fa, FESpace(Γ,reffe))
+
+# "evaluate" at an arbitrary point on the "surface" FESpace
+@show fΓ( Point(0.52, 0.5) ) 
+
+
+# The above evalute call fails in Gridap v0.17.16, 
+# with the following error
+# ERROR: LoadError: DimensionMismatch: matrix is not square: dimensions are (1, 2)
+
+# Corrections
+# Modified src/Fields/AffineMaps.jl
+
+end


### PR DESCRIPTION
Consider a FieldFEFunction defined only at a boundary of the domain. A user may need to calculate the FieldFEFunction at an arbitrary point using `evaluate()`.
At the moment, this results in a dimension mismatch error, because it requires the inversion of a rectangular matrix.
Please see "test/GridapTests/issue_873.jl"

The proposed edits resolves the error using pseudoinverse for the rectangular matrix, thus enabling the calculation of a FieldFEFunction at an arbitrary point using `evaluate()`.