### PR TITLE
deleting nede_tet_1.vtu generated during NedelecRefFEs tests

### DIFF
--- a/test/ReferenceFEsTests/NedelecRefFEsTests.jl
+++ b/test/ReferenceFEsTests/NedelecRefFEsTests.jl
@@ -156,6 +156,9 @@ ux = evaluate(shapes,x)
 gux = evaluate(gshapes,x)
 ndat = ["s$i"=>ux[:,i] for i in 1:num_dofs(reffe)]
 gndat = ["g$i"=>gux[:,i] for i in 1:num_dofs(reffe)]
-writevtk(grid,"nede_tet_1",nodaldata=vcat(ndat,gndat))
+d = mktempdir()
+f = joinpath(d, "nede_tet_1")
+writevtk(grid,f,nodaldata=vcat(ndat,gndat))
+rm(d,recursive=true)
 
 end # module

--- a/test/ReferenceFEsTests/runtests.jl
+++ b/test/ReferenceFEsTests/runtests.jl
@@ -34,6 +34,8 @@ using Test
 
 @testset "NedelecRefFEs" begin include("NedelecRefFEsTests.jl") end
 
+rm("nede_tet_1.vtu", force=true)
+
 @testset "CDLagrangianRefFEs" begin include("CDLagrangianRefFEsTests.jl") end
 
 @testset "BezierRefFEs" begin include("BezierRefFEsTests.jl") end

--- a/test/ReferenceFEsTests/runtests.jl
+++ b/test/ReferenceFEsTests/runtests.jl
@@ -34,8 +34,6 @@ using Test
 
 @testset "NedelecRefFEs" begin include("NedelecRefFEsTests.jl") end
 
-rm("nede_tet_1.vtu", force=true)
-
 @testset "CDLagrangianRefFEs" begin include("CDLagrangianRefFEsTests.jl") end
 
 @testset "BezierRefFEs" begin include("BezierRefFEsTests.jl") end


### PR DESCRIPTION
The "`nede_tet_1.vtu`" file is generated from the `NedelecRefFEs` tests, I am adding a line to delete it, as overlooking it after performing global tests on local machine could add it to the git branch. I added it outside `NedelecRefFEsTests.jl` file so that testing only this particular module, can allow us to inspect the "`nede_tet_1.vtu`" (which I think is its purpose?) rather than automatically deleting it (of course, in that case we have to delete it ourselves, but it is inconvenient while performing global tests). 