### PR TITLE
Reimplement `DomainStyle` for `CellQuadrature`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Reimplemented `DomainStyle` for `CellQuadrature` to fix breaking low-level Poisson tutorial. Since PR [#937](https://github.com/gridap/Gridap.jl/pull/937).
+
 ## [0.17.18] - 2023-08-15 
 
 ### Added

--- a/src/CellData/CellQuadratures.jl
+++ b/src/CellData/CellQuadratures.jl
@@ -124,6 +124,7 @@ end
 
 get_data(f::CellQuadrature) = f.cell_quad
 get_triangulation(f::CellQuadrature) = f.trian
+DomainStyle(::Type{CellQuadrature{DDS,IDS}}) where {DDS,IDS} = DDS()
 
 function change_domain(a::CellQuadrature,::ReferenceDomain,::PhysicalDomain)
   @notimplemented


### PR DESCRIPTION
This PR fixes the low-level tutorial, breaking due to #885, as noted by @JordiManyer (thanks).

See [here](https://github.com/gridap/Tutorials/pull/170#issuecomment-1687218218)  for details.

@amartinhuertas, could you please review and accept, whenever you have some time? Thanks.