### PR TITLE
Implementing Explicit Runge Kutta Methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Implemented real/imag for VectorValues
+- Explicit Runge-Kutta ODE Solvers. Since PR [#952](https://github.com/gridap/Gridap.jl/pull/952)
 
 ### Fixed
 

--- a/docs/ODEs.md
+++ b/docs/ODEs.md
@@ -50,7 +50,7 @@ or
 $$
 M \delta k_s = - M k_s -K(t_n + c_s \delta t,  u^{n} + \delta t \sum_{i=1}^{s} a_{s,i} k_i, k_s).
 $$ 
-Then, $u^{n+1} = u^n + \delta t \sum_{i=1}^{n} b_i k_i$. Note that we are only considering DIRK methods, since we only allow $i = 1, \ldots, s$ at each stage computation. In this case, the jacobians to be computed are as above, $J_0$ and $J_1$. However, $J_0 = M$ and $J_1 = \frac{\partial K}{\partial u}$. In any case, we could just define $A$ as above and compute its Jacobians as above. 
+Then, $u^{n+1} = u^n + \delta t \sum_{i=1}^{n} b_i k_i$. Note that we are only considering DIRK methods, since we only allow $i = 1, \ldots, s$ at each stage computation. In this case, the jacobians to be computed are as above, $J_0$ and $J_1$. However, $J_1 = M$ and $J_0 = \frac{\partial K}{\partial u}$. In any case, we could just define $A$ as above and compute its Jacobians as above. 
 
 At each stage, we have $\gamma_1^s = 1$ and $\gamma_0^s = \delta t a_{s,s}$. We can use exactly the same machinery as above with these coefficients.
 

--- a/docs/ODEs.md
+++ b/docs/ODEs.md
@@ -1,0 +1,35 @@
+Let us consider the transient problem $A(u,\dot{u}) = 0$. We can consider that this is a ODE, since the spatial part is not important here. The most standard situation is the one in which
+$$
+A(u,d_t{u}) = Md_t{u} + K u,
+$$
+i.e., $A$ is linear with respect to $\dot{u}$, but we can consider the more general case here. 
+
+Our motivation here is to split the time domain into time steps, and for each time step $[t^n,t^{n+1}]$, create an approximation of the map $u^n \mapsto u^{n+1}$ such that $A(R(u^{n+1},u^n),\Delta_t(u^{n+1},u^n)) = 0$. The operator $\Delta_t$ is an approximation of the time derivative and the operator $R$ is some time approximation of $u$ in $[t^n,t^{n+1}]$.  
+
+Let us consider the $θ$-method to fix ideas. In this case, we consider at each time step the initial value $u^n$, we approximate the time derivative using finite differences as $\Delta_t(u^n,u^{n+1}) = \frac{u^{n+1}-u^{n}}{\delta t}$. For Backward-Euler, we compute $R(u^n,u^{n+1}) = u^{n+1}$, for Forward Euler $R(u^n,u^{n+1}) = u^{n}$, and for Crank-Nicolson $R(u^n,u^{n+1}) = \frac{u^{n+1}+u^{n}}{2}$ (or more precisely, $R(u^n,u^{n+1}) = u^{n+1}(t-t^n) + u^n(t^{n+1}-t)$).
+
+Now, we want to approximate the operator using any of these methods. We can readily check that we can write the Newton linearisation of any of these problems as: 
+$$
+[\frac{∂A}{∂u}\frac{\partial R}{\partial u^{n+1}}  + \frac{∂A}{∂\dot{u}}\frac{\partial \Delta}{\partial u^{n+1}} ] \delta u^{n+1}  = - A(R(u^{n+1},u^n),\Delta_t(u^{n+1},u^n)).
+$$
+We can denote $J_0 \doteq \frac{∂A}{∂u}$ and $J_1 \doteq \frac{∂A}{∂\dot{u}}$.
+
+E.g., for BE we have 
+$$
+\frac{\partial R}{\partial u^{n+1}} = 1, \qquad \frac{\partial \Delta}{\partial u^{n+1}} = 1/δt,
+$$
+for FE we have
+$$
+\frac{\partial R}{\partial u^{n+1}} = 0, \qquad \frac{\partial \Delta}{\partial u^{n+1}} = 1/δt,
+$$
+and for CN we have 
+$$
+\frac{\partial R}{\partial u^{n+1}} = 1/2, \qquad \frac{\partial \Delta}{\partial u^{n+1}} = 1/δt.
+$$
+Analogously, we can define $\gamma_0 \doteq \frac{\partial R}{\partial u^{n+1}}$ and $\gamma_1 \doteq \frac{\partial \Delta}{\partial u^{n+1}}$. Note that the standard Jacobian is pre-multiplied by $\gamma_0$. Thus, it makes no sense to compute $J_0$ when $\gamma_0 = 0$. The same happens for the case of $\gamma_1 = 0$ and $J_1$. But this is not the case for ODEs. $J_1$ is the mass matrix.      
+
+We have decided to write the problem in terms of $u^{n+1}$, but we could do something different. E.g., for the $\theta$-method, we can write the problem in terms of $u^{n+\theta}$ for $\theta > 0$. In this case, we have to define the $R$ and $Δ_t$ operators in terms of $u^{n+\theta}$ and $u^n$ and perform exactly as above. The only difference is a final update step. 
+
+From the discussion above, it seems quite clear that FE should work with the current machinery, since we would be computing $M + 0*L$. That is the reason why I say that the current machinery should work for FE but we need to avoid computing $L$ by using a if statement in the code, and only compute it for $\gamma_0 > 0$.
+
+When FE works, we can start the discussion about the general RK solver.

--- a/docs/ODEs.md
+++ b/docs/ODEs.md
@@ -4,6 +4,8 @@ A(u,d_t{u}) = Md_t{u} + K u,
 $$
 i.e., $A$ is linear with respect to $\dot{u}$, but we can consider the more general case here. 
 
+# $θ$-method 
+
 Our motivation here is to split the time domain into time steps, and for each time step $[t^n,t^{n+1}]$, create an approximation of the map $u^n \mapsto u^{n+1}$ such that $A(R(u^{n+1},u^n),\Delta_t(u^{n+1},u^n)) = 0$. The operator $\Delta_t$ is an approximation of the time derivative and the operator $R$ is some time approximation of $u$ in $[t^n,t^{n+1}]$.  
 
 Let us consider the $θ$-method to fix ideas. In this case, we consider at each time step the initial value $u^n$, we approximate the time derivative using finite differences as $\Delta_t(u^n,u^{n+1}) = \frac{u^{n+1}-u^{n}}{\delta t}$. For Backward-Euler, we compute $R(u^n,u^{n+1}) = u^{n+1}$, for Forward Euler $R(u^n,u^{n+1}) = u^{n}$, and for Crank-Nicolson $R(u^n,u^{n+1}) = \frac{u^{n+1}+u^{n}}{2}$ (or more precisely, $R(u^n,u^{n+1}) = u^{n+1}(t-t^n) + u^n(t^{n+1}-t)$).
@@ -33,3 +35,23 @@ We have decided to write the problem in terms of $u^{n+1}$, but we could do some
 From the discussion above, it seems quite clear that FE should work with the current machinery, since we would be computing $M + 0*L$. That is the reason why I say that the current machinery should work for FE but we need to avoid computing $L$ by using a if statement in the code, and only compute it for $\gamma_0 > 0$.
 
 When FE works, we can start the discussion about the general RK solver.
+
+# RK methods
+
+In DIRK methods, we make the following assumption:
+$$
+A(t,u,d_t(u)) \doteq M d_t(u) + K(t,u) = 0.
+$$
+Given a Butcher tableau, the method reads as follows. Given $u^{n}$, compute for $s = 1,\ldots,n$,
+$$
+M k_s = -K(t_n + c_s \delta t,  u^{n} + \delta t \sum_{i=1}^{s} a_{s,i} k_i),
+$$
+or
+$$
+M \delta k_s = - M k_s -K(t_n + c_s \delta t,  u^{n} + \delta t \sum_{i=1}^{s} a_{s,i} k_i, k_s).
+$$ 
+Then, $u^{n+1} = u^n + \delta t \sum_{i=1}^{n} b_i k_i$. Note that we are only considering DIRK methods, since we only allow $i = 1, \ldots, s$ at each stage computation. In this case, the jacobians to be computed are as above, $J_0$ and $J_1$. However, $J_0 = M$ and $J_1 = \frac{\partial K}{\partial u}$. In any case, we could just define $A$ as above and compute its Jacobians as above. 
+
+At each stage, we have $\gamma_1^s = 1$ and $\gamma_0^s = \delta t a_{s,s}$. We can use exactly the same machinery as above with these coefficients.
+
+In the case of explicit methods, $a_{s,s} = 0$ and we don't need to compute $J_0$, as above for FE.   

--- a/src/ODEs/Exports.jl
+++ b/src/ODEs/Exports.jl
@@ -11,6 +11,7 @@ end
 @publish_gridapodes ODETools ThetaMethod
 @publish_gridapodes ODETools RungeKutta
 @publish_gridapodes ODETools IMEXRungeKutta
+@publish_gridapodes ODETools EXRungeKutta
 @publish_gridapodes ODETools Newmark
 @publish_gridapodes ODETools GeneralizedAlpha
 @publish_gridapodes ODETools ∂t
@@ -26,3 +27,4 @@ end
 @publish_gridapodes TransientFETools TransientConstantMatrixFEOperator
 @publish_gridapodes TransientFETools TransientRungeKuttaFEOperator
 @publish_gridapodes TransientFETools TransientIMEXRungeKuttaFEOperator
+@publish_gridapodes TransientFETools TransientEXRungeKuttaFEOperator

--- a/src/ODEs/ODETools/EXRungeKutta.jl
+++ b/src/ODEs/ODETools/EXRungeKutta.jl
@@ -1,0 +1,148 @@
+"""
+Explicit Runge-Kutta ODE solver
+"""
+struct EXRungeKutta <: ODESolver
+  nls::NonlinearSolver
+  dt::Float64
+  tableau::EXButcherTableau
+  function EXRungeKutta(nls::NonlinearSolver, dt, type::Symbol)
+    bt = EXButcherTableau(type)
+    new(nls, dt, bt)
+  end
+end
+
+"""
+solve_step!(uf,odesol,op,u0,t0,cache)
+"""
+function solve_step!(uf::AbstractVector,
+  solver::EXRungeKutta,
+  op::ODEOperator,
+  u0::AbstractVector,
+  t0::Real,
+  cache)
+
+  # Unpack variables
+  dt = solver.dt
+  s = solver.tableau.s
+  a = solver.tableau.a
+  b = solver.tableau.b
+  c = solver.tableau.c
+  d = solver.tableau.d
+
+  # Create cache if not there
+  if cache === nothing
+    ode_cache = allocate_cache(op)
+    vi = similar(u0)
+    ki = [similar(u0) for i in 1:s]
+    M = allocate_jacobian(op,t0,uf,ode_cache)
+    get_mass_matrix!(M,op,t0,uf,ode_cache)
+    nl_cache = nothing
+  else
+    ode_cache, vi, ki, M, nl_cache = cache
+  end
+
+  nlop = EXRungeKuttaStageNonlinearOperator(op,t0,dt,u0,ode_cache,vi,ki,0,a,M)
+
+  for i in 1:s
+
+    # solve at stage i
+    ti = t0 + c[i]*dt
+    ode_cache = update_cache!(ode_cache,op,ti)
+    update!(nlop,ti,ki[i],i)
+    nl_cache = solve!(uf,solver.nls,nlop,nl_cache)
+
+    update!(nlop,ti,uf,i)
+
+  end
+
+  # update final solution
+  tf = t0 + dt
+
+  @. uf = u0
+  for i in 1:s
+  @. uf = uf + dt*b[i]*nlop.ki[i]
+  end
+
+  cache = (ode_cache, vi, ki, M, nl_cache)
+
+  return (uf,tf,cache)
+
+
+end
+
+
+
+
+mutable struct EXRungeKuttaStageNonlinearOperator <: RungeKuttaNonlinearOperator
+  odeop::ODEOperator
+  ti::Float64
+  dt::Float64
+  u0::AbstractVector
+  ode_cache
+  vi::AbstractVector
+  ki::AbstractVector
+  i::Int
+  a::Matrix
+  M::AbstractMatrix
+end
+
+
+"""
+ODE:    A(t,u,∂u  = M ∂u/∂t + K(t,u) = 0 -> solve for u
+EX-RK:  A(t,u,ki) = M ki    + K(ti,u0 + dt ∑_{j<i} a_ij * kj) = 0 -> solve for ki
+                  = M ki    + K(ti,ui) = 0
+
+For forward euler,          i = 1     -> ui = u0
+For other explicit methods, i = 1,…,s -> ui = u0 + dt ∑_{j<i} a_ij * kj
+
+For EX-RK, the Jacobian is always M. At each solve_step, compute and store M in
+nlop
+
+"""
+function residual!(b::AbstractVector,op::EXRungeKuttaStageNonlinearOperator,x::AbstractVector)
+
+  ui = x
+  vi = op.vi
+
+  lhs!(b,op.odeop,op.ti,(ui,vi),op.ode_cache)
+
+  @. ui = op.u0
+  for j = 1:op.i-1
+   @. ui = ui  + op.dt * op.a[op.i,j] * op.ki[j]
+  end
+
+  rhs = similar(op.u0)
+  rhs!(rhs,op.odeop,op.ti,(ui,vi),op.ode_cache)
+
+  @. b = b + rhs
+  @. b = -1.0 * b
+  b
+end
+
+function jacobian!(A::AbstractMatrix,op::EXRungeKuttaStageNonlinearOperator,x::AbstractVector)
+   @. A = op.M
+end
+
+
+function allocate_residual(op::EXRungeKuttaStageNonlinearOperator,x::AbstractVector)
+  allocate_residual(op.odeop,op.ti,x,op.ode_cache)
+end
+
+function allocate_jacobian(op::EXRungeKuttaStageNonlinearOperator,x::AbstractVector)
+  allocate_jacobian(op.odeop,op.ti,x,op.ode_cache)
+end
+
+
+function update!(op::EXRungeKuttaStageNonlinearOperator,ti::Float64,ki::AbstractVector,i::Int)
+  op.ti = ti
+  @. op.ki[i] = ki
+  op.i = i
+end
+
+
+function get_mass_matrix!(A::AbstractMatrix,odeop::ODEOperator,t0::Float64,u0::AbstractVector,ode_cache)
+  z = zero(eltype(A))
+  fillstored!(A,z)
+  jacobian!(A,odeop,t0,(u0,u0),2,1.0,ode_cache)
+  A
+end

--- a/src/ODEs/ODETools/ODESolvers.jl
+++ b/src/ODEs/ODETools/ODESolvers.jl
@@ -57,6 +57,8 @@ include("RungeKutta.jl")
 
 include("IMEXRungeKutta.jl")
 
+include("EXRungeKutta.jl")
+
 include("Newmark.jl")
 
 include("AffineNewmark.jl")

--- a/src/ODEs/ODETools/ODETools.jl
+++ b/src/ODEs/ODETools/ODETools.jl
@@ -71,6 +71,7 @@ export MidPoint
 export ThetaMethod
 export RungeKutta
 export IMEXRungeKutta
+export EXRungeKutta
 export Newmark
 export GeneralizedAlpha
 

--- a/src/ODEs/ODETools/Tableaus.jl
+++ b/src/ODEs/ODETools/Tableaus.jl
@@ -190,3 +190,69 @@ end
 function IMEXButcherTableau(type::Symbol)
   eval(:(IMEXButcherTableau($type())))
 end
+
+"""
+Explicit Butcher tableaus
+"""
+
+abstract type EXButcherTableauType end
+
+struct EX_FE_1_0_1 <: EXButcherTableauType end
+struct EX_SSP_3_0_3 <: EXButcherTableauType end
+
+"""
+Explicit Butcher tableaus
+"""
+struct EXButcherTableau{T <: EXButcherTableauType}
+  s::Int # stages
+  p::Int # embedded order
+  q::Int # order
+  a::Matrix # A_ij explicit
+  b::Vector # b_j explicit
+  c::Vector # c_i explicit
+  d::Vector # d_j (embedded)
+end
+
+# EX Butcher Tableaus constructors
+
+"""
+EX Forward-Backward-Euler
+
+number of stages: 1
+embedded method: no
+order: 1
+"""
+function EXButcherTableau(::EX_FE_1_0_1)
+  s = 1
+  p = 0
+  q = 1
+  a = reshape([0.0],1,1)
+  b = [1.0]
+  c = [0.0]
+  d = [0.0]
+  EXButcherTableau{EX_FE_1_0_1}(s,p,q,a,b,c,d)
+end
+
+"""
+EX SSPRK3
+
+number of stages: 3
+embedded method: no
+order: 3
+"""
+function EXButcherTableau(::EX_SSP_3_0_3)
+  s = 3
+  p = 0
+  q = 3
+  a = [0.0 0.0 0.0; 1.0 0.0 0.0; 1/4 1/4 0.0]
+  b = [1/6, 1/6, 2/3]
+  c = [0.0, 1.0, 1/2]
+  d = [0.0, 0.0, 0.0]
+
+
+  EXButcherTableau{EX_SSP_3_0_3}(s,p,q,a,b,c,d)
+end
+
+function EXButcherTableau(type::Symbol)
+  eval(:(EXButcherTableau($type())))
+end

--- a/src/ODEs/TransientFETools/TransientFETools.jl
+++ b/src/ODEs/TransientFETools/TransientFETools.jl
@@ -41,6 +41,7 @@ export TransientConstantFEOperator
 export TransientConstantMatrixFEOperator
 export TransientRungeKuttaFEOperator
 export TransientIMEXRungeKuttaFEOperator
+export TransientEXRungeKuttaFEOperator
 using Gridap.FESpaces: Assembler
 using Gridap.FESpaces: SparseMatrixAssembler
 import Gridap.ODEs.ODETools: allocate_cache

--- a/test/ODEsTests/ODEsTests/ODEOperatorMocks.jl
+++ b/test/ODEsTests/ODEsTests/ODEOperatorMocks.jl
@@ -1,6 +1,9 @@
 # Toy linear ODE with 2 DOFs
 # u_1_t - a * u_1 = 0
 # u_2_t - b * u_1 - c * u_2 = 0
+# For a = 1, b = 0, c = 1, the analytical solution is:
+# u_1 = u0*exp(t)
+# u_2 = u0*exp(t)
 
 # Toy 2nd order ODE with 2 DOFs
 # u_1_tt + b * u_1_t - a * u_1 = 0

--- a/test/ODEsTests/ODEsTests/ODESolversTests.jl
+++ b/test/ODEsTests/ODEsTests/ODESolversTests.jl
@@ -6,6 +6,7 @@ using Gridap.ODEs.ODETools: BackwardEuler
 using Gridap.ODEs.ODETools: RungeKutta
 using Gridap.ODEs.ODETools: IMEXRungeKutta
 using Gridap.ODEs.ODETools: EXRungeKutta
+using Gridap.ODEs.ODETools: ForwardEuler
 using Gridap.ODEs.ODETools: ThetaMethodNonlinearOperator
 using Gridap.ODEs.ODETools: GeneralizedAlpha
 using Gridap.ODEs.ODETools: solve!
@@ -178,7 +179,7 @@ odesol = EXRungeKutta(ls,dt,:EX_FE_1_0_1)
 cache = nothing
 uf, tf, cache = solve_step!(uf,odesol,op,u0,t0,cache)
 @test tf==t0+dt
-@test all(uf.≈u0*1.1)
+@test all( (uf.- u0*1.1)  .< 1e-3 )
 @test test_ode_solver(odesol,op,u0,t0,tf)
 
 # EX-RK: SSP equivalent
@@ -186,7 +187,7 @@ odesol = EXRungeKutta(ls,dt,:EX_SSP_3_0_3)
 cache = nothing
 uf, tf, cache = solve_step!(uf,odesol,op,u0,t0,cache)
 @test tf==t0+dt
-@test all(uf.≈u0*1.1051666666666666)
+@test all( (uf.- u0*1.105166) .< 1e-3 )
 @test test_ode_solver(odesol,op,u0,t0,tf)
 
 # Forward Euler test
@@ -194,7 +195,7 @@ odesol = ForwardEuler(ls,dt)
 cache = nothing
 uf, tf, cache = solve_step!(uf,odesol,op,u0,t0,cache)
 @test tf==t0+dt
-@test all(uf.≈u0*1.1)
+@test all( (uf.- u0*1.1)  .< 1e-3 )
 @test test_ode_solver(odesol,op,u0,t0,tf)
 
 # Newmark test

--- a/test/ODEsTests/ODEsTests/ODESolversTests.jl
+++ b/test/ODEsTests/ODEsTests/ODESolversTests.jl
@@ -101,13 +101,14 @@ _J = jacobian(sop,x)
 ls = LUSolver()
 
 # BackwardEuler tests
+dt = 0.01
 odesol = BackwardEuler(ls,dt)
 uf = copy(u0)
 uf.=1.0
 cache = nothing
 uf, tf, cache = solve_step!(uf,odesol,op,u0,t0,cache)
 @test tf==t0+dt
-@test all(uf.≈1+11/9)
+@test all( (uf.- u0*exp(dt))  .< 1e-3 )
 @test test_ode_solver(odesol,op,u0,t0,tf)
 
 # Affine and nonlinear solvers
@@ -115,14 +116,14 @@ op = ODEOperatorMock{Float64,Nonlinear}(1.0,0.0,1.0,1)
 cache = nothing
 uf, tf, cache = solve_step!(uf,odesol,op,u0,t0,cache)
 @test tf==t0+dt
-@test all(uf.≈1+11/9)
+@test all( (uf.- u0*exp(dt))  .< 1e-3 )
 @test test_ode_solver(odesol,op,u0,t0,tf)
 
 op = ODEOperatorMock{Float64,Affine}(1.0,0.0,1.0,1)
 cache = nothing
 uf, tf, cache = solve_step!(uf,odesol,op,u0,t0,cache)
 @test tf==t0+dt
-@test all(uf.≈1+11/9)
+@test all( (uf.- u0*exp(dt))  .< 1e-3 )
 @test test_ode_solver(odesol,op,u0,t0,tf)
 
 # ThetaMethod tests
@@ -130,7 +131,7 @@ odesolθ = ThetaMethod(ls,dt,0.5)
 ufθ = copy(u0)
 ufθ.=1.0
 ufθ, tf, cache = solve_step!(ufθ,odesolθ,op,u0,t0,nothing)
-@test all(ufθ.≈(dt/(1-0.5dt) + 1)*u0)
+@test all( (uf.- u0*exp(dt))  .< 1e-3 )
 @test test_ode_solver(odesol,op,u0,t0,tf)
 
 # RK tests
@@ -139,7 +140,7 @@ odesol = RungeKutta(ls,ls,dt,:BE_1_0_1)
 cache = nothing
 uf, tf, cache = solve_step!(uf,odesol,op,u0,t0,cache)
 @test tf==t0+dt
-@test all(uf.≈1+11/9)
+@test all( (uf.- u0*exp(dt))  .< 1e-3 )
 @test test_ode_solver(odesol,op,u0,t0,tf)
 
 # RK: CN 2nd order
@@ -147,7 +148,7 @@ odesol = RungeKutta(ls,ls,dt,:CN_2_0_2)
 cache = nothing
 uf, tf, cache = solve_step!(uf,odesol,op,u0,t0,cache)
 @test tf==t0+dt
-@test all(uf.≈ufθ)
+@test all( (uf.- u0*exp(dt))  .< 1e-3 )
 @test test_ode_solver(odesol,op,u0,t0,tf)
 
 # RK: SDIRK 2nd order
@@ -155,7 +156,7 @@ odesol = RungeKutta(ls,ls,dt,:SDIRK_2_0_2)
 cache = nothing
 uf, tf, cache = solve_step!(uf,odesol,op,u0,t0,cache)
 @test tf==t0+dt
-@test all(uf.≈u0*1.1051939513477975)
+@test all( (uf.- u0*exp(dt))  .< 1e-3 )
 @test test_ode_solver(odesol,op,u0,t0,tf)
 
 # RK: TRBDF (2nd order with some 0 on the diagonal)
@@ -163,7 +164,7 @@ odesol = RungeKutta(ls,ls,dt,:TRBDF2_3_2_3)
 cache = nothing
 uf, tf, cache = solve_step!(uf,odesol,op,u0,t0,cache)
 @test tf==t0+dt
-@test all(uf.≈u0*1.105215241)
+@test all( (uf.- u0*exp(dt))  .< 1e-3 )
 @test test_ode_solver(odesol,op,u0,t0,tf)
 
 # IMEX RK tests (explicit part = 0)
@@ -171,7 +172,7 @@ odesol = IMEXRungeKutta(ls,ls,dt,:IMEX_FE_BE_2_0_1)
 cache = nothing
 uf, tf, cache = solve_step!(uf,odesol,op,u0,t0,cache)
 @test tf==t0+dt
-@test all(uf.≈1+11/9)
+@test all( (uf.- u0*exp(dt))  .< 1e-3 )
 @test test_ode_solver(odesol,op,u0,t0,tf)
 
 # EX-RK: FE equivalent
@@ -179,7 +180,7 @@ odesol = EXRungeKutta(ls,dt,:EX_FE_1_0_1)
 cache = nothing
 uf, tf, cache = solve_step!(uf,odesol,op,u0,t0,cache)
 @test tf==t0+dt
-@test all( (uf.- u0*1.1)  .< 1e-3 )
+@test all( (uf.- u0*exp(dt))  .< 1e-3 )
 @test test_ode_solver(odesol,op,u0,t0,tf)
 
 # EX-RK: SSP equivalent
@@ -187,7 +188,7 @@ odesol = EXRungeKutta(ls,dt,:EX_SSP_3_0_3)
 cache = nothing
 uf, tf, cache = solve_step!(uf,odesol,op,u0,t0,cache)
 @test tf==t0+dt
-@test all( (uf.- u0*1.105166) .< 1e-3 )
+@test all( (uf.- u0*exp(dt))  .< 1e-3 )
 @test test_ode_solver(odesol,op,u0,t0,tf)
 
 # Forward Euler test
@@ -195,7 +196,7 @@ odesol = ForwardEuler(ls,dt)
 cache = nothing
 uf, tf, cache = solve_step!(uf,odesol,op,u0,t0,cache)
 @test tf==t0+dt
-@test all( (uf.- u0*1.1)  .< 1e-3 )
+@test all( (uf.- u0*exp(dt))  .< 1e-3 )
 @test test_ode_solver(odesol,op,u0,t0,tf)
 
 # Newmark test

--- a/test/ODEsTests/ODEsTests/ODESolversTests.jl
+++ b/test/ODEsTests/ODEsTests/ODESolversTests.jl
@@ -189,6 +189,13 @@ uf, tf, cache = solve_step!(uf,odesol,op,u0,t0,cache)
 @test all(uf.≈u0*1.1051666666666666)
 @test test_ode_solver(odesol,op,u0,t0,tf)
 
+# Forward Euler test
+odesol = ForwardEuler(ls,dt)
+cache = nothing
+uf, tf, cache = solve_step!(uf,odesol,op,u0,t0,cache)
+@test tf==t0+dt
+@test all(uf.≈u0*1.1)
+@test test_ode_solver(odesol,op,u0,t0,tf)
 
 # Newmark test
 op_const = ODEOperatorMock{Float64,Constant}(1.0,0.0,0.0,2)

--- a/test/ODEsTests/ODEsTests/ODESolversTests.jl
+++ b/test/ODEsTests/ODEsTests/ODESolversTests.jl
@@ -178,7 +178,15 @@ odesol = EXRungeKutta(ls,dt,:EX_FE_1_0_1)
 cache = nothing
 uf, tf, cache = solve_step!(uf,odesol,op,u0,t0,cache)
 @test tf==t0+dt
-@test all(uf.≈1+11/9)
+@test all(uf.≈u0*1.1)
+@test test_ode_solver(odesol,op,u0,t0,tf)
+
+# EX-RK: SSP equivalent
+odesol = EXRungeKutta(ls,dt,:EX_SSP_3_0_3)
+cache = nothing
+uf, tf, cache = solve_step!(uf,odesol,op,u0,t0,cache)
+@test tf==t0+dt
+@test all(uf.≈u0*1.1051666666666666)
 @test test_ode_solver(odesol,op,u0,t0,tf)
 
 

--- a/test/ODEsTests/ODEsTests/ODESolversTests.jl
+++ b/test/ODEsTests/ODEsTests/ODESolversTests.jl
@@ -1,9 +1,11 @@
-# module ODESolversTests
+module ODESolversTests
 
 using Gridap.ODEs
 using Gridap.ODEs.ODETools: GenericODESolution
 using Gridap.ODEs.ODETools: BackwardEuler
 using Gridap.ODEs.ODETools: RungeKutta
+using Gridap.ODEs.ODETools: IMEXRungeKutta
+using Gridap.ODEs.ODETools: EXRungeKutta
 using Gridap.ODEs.ODETools: ThetaMethodNonlinearOperator
 using Gridap.ODEs.ODETools: GeneralizedAlpha
 using Gridap.ODEs.ODETools: solve!
@@ -171,6 +173,14 @@ uf, tf, cache = solve_step!(uf,odesol,op,u0,t0,cache)
 @test all(uf.≈1+11/9)
 @test test_ode_solver(odesol,op,u0,t0,tf)
 
+# EX-RK: FE equivalent
+odesol = EXRungeKutta(ls,dt,:EX_FE_1_0_1)
+cache = nothing
+uf, tf, cache = solve_step!(uf,odesol,op,u0,t0,cache)
+@test tf==t0+dt
+@test all(uf.≈1+11/9)
+@test test_ode_solver(odesol,op,u0,t0,tf)
+
 
 # Newmark test
 op_const = ODEOperatorMock{Float64,Constant}(1.0,0.0,0.0,2)
@@ -244,4 +254,4 @@ afα = copy(a0)
 @test sqrt(sum(abs2.(vfα - vfN))) < 1.0e-10
 @test sqrt(sum(abs2.(afα - afN))) < 1.0e-10
 
-# end #module
+end #module

--- a/test/ODEsTests/TransientFEsTests/HeatEquationAutoDiffTests.jl
+++ b/test/ODEsTests/TransientFEsTests/HeatEquationAutoDiffTests.jl
@@ -68,7 +68,7 @@ uh0 = interpolate_everywhere(u(0.0),U0)
 
 ls = LUSolver()
 using Gridap.Algebra: NewtonRaphsonSolver
-nls = NLSolver(ls;show_trace=true,method=:newton) #linesearch=BackTracking())
+nls = NLSolver(ls;show_trace=false,method=:newton) #linesearch=BackTracking())
 ode_solver = ThetaMethod(ls,dt,θ)
 
 sol_t = solve(ode_solver,op,uh0,t0,tF)

--- a/test/ODEsTests/TransientFEsTests/HeatEquationTests.jl
+++ b/test/ODEsTests/TransientFEsTests/HeatEquationTests.jl
@@ -50,7 +50,7 @@ uh0 = interpolate_everywhere(u(0.0),U0)
 
 ls = LUSolver()
 using Gridap.Algebra: NewtonRaphsonSolver
-nls = NLSolver(ls;show_trace=true,method=:newton) #linesearch=BackTracking())
+nls = NLSolver(ls;show_trace=false,method=:newton) #linesearch=BackTracking())
 ode_solver = ThetaMethod(ls,dt,θ)
 
 sol_t = solve(ode_solver,op,uh0,t0,tF)

--- a/test/ODEsTests/TransientFEsTests/TransientFETests.jl
+++ b/test/ODEsTests/TransientFEsTests/TransientFETests.jl
@@ -112,7 +112,7 @@ ls = LUSolver()
 tol = 1.0
 maxiters = 20
 using Gridap.Algebra: NewtonRaphsonSolver
-nls = NLSolver(ls;show_trace=true,method=:newton) #linesearch=BackTracking())
+nls = NLSolver(ls;show_trace=false,method=:newton) #linesearch=BackTracking())
 ode_solver = ThetaMethod(nls,dt,1.0)
 @test test_transient_fe_solver(ode_solver,op,uh0,t0,tF)
 


### PR DESCRIPTION
This is a clean version of [PR#951](https://github.com/gridap/Gridap.jl/pull/951) for explicit Runge Kutta.

In this PR, I have implemented multi-stage, explicit Runge Kutta method in EXRungeKutta.jl. This follows the format and structure of RungeKutta.jl and IMEXRungeKutta.jl.

I have added an additional operator TransientEXRungeKuttaFEOperator. However, I think this can be combined with TransientRungeKuttaFEOperator to have one operator which works for both explicit and diagonally implicit Runge Kutta (IMEX will probably still require its own operator).

@santiagobadia can you please review this PR

Thanks
