### PR TITLE
Bugfix: distributed `add_tag_from_tags!` not working

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `BlockMultiFieldStyle` available for `TransientMultiFieldFESpaces` since PR [#946](https://github.com/gridap/Gridap.jl/pull/946).
+- When creating `DiscreteModelPortions`, some of the `FaceLabeling` arrays were being aliased. This caused issues when adding tags to distributed models in debug mode. Since PR [#956](https://github.com/gridap/Gridap.jl/pull/956).
 
 ## [0.17.20] - 2023-10-01 
 

--- a/src/Geometry/DiscreteModelPortions.jl
+++ b/src/Geometry/DiscreteModelPortions.jl
@@ -164,7 +164,9 @@ function _setup_labels_p(labels,d_to_dface_to_parent_dface)
     _update_labels_dim!(face_to_label,oface_to_label,face_to_oface)
   end
 
-  FaceLabeling(d_to_dface_to_entity,labels.tag_to_entities,labels.tag_to_name)
+  tag_to_entities = copy(labels.tag_to_entities)
+  tag_to_name     = copy(labels.tag_to_name)
+  FaceLabeling(d_to_dface_to_entity,tag_to_entities,tag_to_name)
 end
 
 function _update_labels_dim!(face_to_label,oface_to_label,face_to_oface)


### PR DESCRIPTION
`add_tag_from_tags!` not working for distributed models created from a single serial model in debug mode. This was caused by arrays being aliased. Fixed by copying the arrays. 