### PR TITLE
Bugfix: add_entry! for PSparseMatrices

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `BlockMultiFieldStyle` available for `TransientMultiFieldFESpaces` since PR [#946](https://github.com/gridap/Gridap.jl/pull/946).
 - When creating `DiscreteModelPortions`, some of the `FaceLabeling` arrays were being aliased. This caused issues when adding tags to distributed models in debug mode. Since PR [#956](https://github.com/gridap/Gridap.jl/pull/956).
+- Function `add_entry!` was inconsistent for `AbstractMatrix` and `AbstractSparseMatrix`. Since PR[#959](https://github.com/gridap/Gridap.jl/pull/959).
 
 ## [0.17.20] - 2023-10-01 
 

--- a/src/Algebra/AlgebraInterfaces.jl
+++ b/src/Algebra/AlgebraInterfaces.jl
@@ -444,7 +444,7 @@ function add_entry!(combine::Function,A::AbstractSparseMatrix,v::Number,i,j)
   k = nz_index(A,i,j)
   nz = nonzeros(A)
   Aij = nz[k]
-  nz[k] = combine(v,Aij)
+  nz[k] = combine(Aij,v)
   A
 end
 

--- a/src/Algebra/SymSparseMatrixCSR.jl
+++ b/src/Algebra/SymSparseMatrixCSR.jl
@@ -35,7 +35,7 @@ function add_entry!(combine::Function,A::SymSparseMatrixCSR,v::Number,i,j)
     k = nz_index(A,i,j)
     nz = nonzeros(A)
     Aij = nz[k]
-    nz[k] = combine(v,Aij)
+    nz[k] = combine(Aij,v)
   end
   A
 end


### PR DESCRIPTION
Copied from [GridapDistributed issue 138](https://github.com/gridap/GridapDistributed.jl/issues/138).

In Gridap, we declare the function `Algebra.add_entry`, which is used to assemble an `(i,j,v)` triplet into different structures (counters, COOs and matrices). As usual, there are different specializations of this function. In particular, we have different functions for `AbstractMatrix` and `AbstractSparseMatrix`: 

```julia
function add_entry!(combine::Function,A::AbstractSparseMatrix,v::Number,i,j)
  k = nz_index(A,i,j)
  nz = nonzeros(A)
  Aij = nz[k]
  nz[k] = combine(v,Aij)
  A
end

@inline function add_entry!(combine::Function,A::AbstractMatrix,v,i,j)
  aij = A[i,j]
  A[i,j] = combine(aij,v)
  A
end
```

As we can see, for `AbstractMatrix` we call `combine(aij,v)` whereas for `AbstractSparseMatrix` we call `combine(v,aij)`. This leads to different behaviors when `combine` is not commutative. For instance, `(a,b) -> a` would create different matrices depending on the type. 