### PR TITLE
Improved allocate_in_range/domain

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Implemented real/imag for VectorValues
 - Explicit Runge-Kutta ODE Solvers. Since PR [#952](https://github.com/gridap/Gridap.jl/pull/952)
+- Improved the methods `allocate_in_range` and `allocate_in_domain` with support for `BlockArrays` and distributed arrays. Since PR[#960](https://github.com/gridap/Gridap.jl/pull/960).
 
 ### Fixed
 
@@ -18,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When creating `DiscreteModelPortions`, some of the `FaceLabeling` arrays were being aliased. This caused issues when adding tags to distributed models in debug mode. Since PR [#956](https://github.com/gridap/Gridap.jl/pull/956).
 - Function `add_entry!` was inconsistent for `AbstractMatrix` and `AbstractSparseMatrix`. Since PR[#959](https://github.com/gridap/Gridap.jl/pull/959).
 
-## [0.17.20] - 2023-10-01 
+## [0.17.20] - 2023-10-01
 
 ### Added
 

--- a/src/Algebra/Algebra.jl
+++ b/src/Algebra/Algebra.jl
@@ -11,6 +11,7 @@ using SparseArrays
 using LinearAlgebra
 using Test
 using SparseMatricesCSR
+using BlockArrays
 
 using Gridap.Helpers
 

--- a/src/Algebra/AlgebraInterfaces.jl
+++ b/src/Algebra/AlgebraInterfaces.jl
@@ -41,14 +41,33 @@ function allocate_vector(::Type{V},n::Integer) where V
   zeros(T,n)
 end
 
+function allocate_vector(::Type{<:BlockVector{T,VV}},indices::BlockedUnitRange) where {T,VV}
+  V = eltype(VV)
+  mortar(map(ids -> allocate_vector(V,ids),blocks(indices)))
+end
+
 """
     allocate_in_range(::Type{V},matrix) where V
 
 Allocate a vector of type `V` in the range of matrix `matrix`.
 """
 function allocate_in_range(::Type{V},matrix) where V
-  n = size(matrix,1)
-  allocate_vector(V,n)
+  rows = axes(matrix,1)
+  allocate_vector(V,rows)
+end
+
+"""
+    allocate_in_range(matrix::AbstractMatrix{T}) where T
+
+Allocate a vector in the range of matrix `matrix`.
+"""
+function allocate_in_range(matrix::AbstractMatrix{T}) where T
+  allocate_in_range(Vector{T},matrix)
+end
+
+function allocate_in_range(matrix::BlockMatrix{T}) where T
+  V = BlockVector{T,Vector{Vector{T}}}
+  allocate_in_range(V,matrix)
 end
 
 """
@@ -57,8 +76,22 @@ end
 Allocate a vector of type `V` in the domain of matrix `matrix`.
 """
 function allocate_in_domain(::Type{V},matrix) where V
-  n = size(matrix,2)
-  allocate_vector(V,n)
+  cols = axes(matrix,2)
+  allocate_vector(V,cols)
+end
+
+"""
+    allocate_in_domain(matrix::AbstractMatrix{T}) where T
+
+Allocate a vector in the domain of matrix `matrix`.
+"""
+function allocate_in_domain(matrix::AbstractMatrix{T}) where T
+  allocate_in_range(Vector{T},matrix)
+end
+
+function allocate_in_domain(matrix::BlockMatrix{T}) where T
+  V = BlockVector{T,Vector{Vector{T}}}
+  allocate_in_domain(V,matrix)
 end
 
 """


### PR DESCRIPTION
Improved the methods `allocate_in_range` and `allocate_in_domain`: 
- The matrix methods now use `axes(A,d)`. This is more general, and will allow us to re-use these methods for distributed matrices. 
- Added new methods that create a 'default' vector type given the input matrix type. 
- Added support for `BlockArrays`, which are used in MultiField. 