### PR TITLE
Changing behaviour for `allocate_vector`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Changed how `allocate_vector` works. Now it only allocates, instead of allocating+initialising to zero. Since PR[#963](https://github.com/gridap/Gridap.jl/pull/963).
+
 ## [0.17.21] - 2023-12-04
 
 ### Added

--- a/src/Algebra/AlgebraInterfaces.jl
+++ b/src/Algebra/AlgebraInterfaces.jl
@@ -37,8 +37,7 @@ function allocate_vector(::Type{V},indices) where V
 end
 
 function allocate_vector(::Type{V},n::Integer) where V
-  T = eltype(V)
-  zeros(T,n)
+  V(undef,n)
 end
 
 function allocate_vector(::Type{<:BlockVector{T,VV}},indices::BlockedUnitRange) where {T,VV}

--- a/src/Algebra/AlgebraInterfaces.jl
+++ b/src/Algebra/AlgebraInterfaces.jl
@@ -86,7 +86,7 @@ end
 Allocate a vector in the domain of matrix `matrix`.
 """
 function allocate_in_domain(matrix::AbstractMatrix{T}) where T
-  allocate_in_range(Vector{T},matrix)
+  allocate_in_domain(Vector{T},matrix)
 end
 
 function allocate_in_domain(matrix::BlockMatrix{T}) where T

--- a/src/FESpaces/FESpaceInterface.jl
+++ b/src/FESpaces/FESpaceInterface.jl
@@ -87,7 +87,9 @@ num_free_dofs(f::FESpace) = length(get_free_dof_ids(f))
 """
 function zero_free_values(f::FESpace)
   V = get_vector_type(f)
-  allocate_vector(V,num_free_dofs(f))
+  dir_values = allocate_vector(V,num_free_dofs(f))
+  fill!(dir_values,zero(eltype(V)))
+  return dir_values
 end
 
 function get_vector_type(fs::FESpace)

--- a/src/FESpaces/FESpaceInterface.jl
+++ b/src/FESpaces/FESpaceInterface.jl
@@ -87,9 +87,9 @@ num_free_dofs(f::FESpace) = length(get_free_dof_ids(f))
 """
 function zero_free_values(f::FESpace)
   V = get_vector_type(f)
-  dir_values = allocate_vector(V,num_free_dofs(f))
-  fill!(dir_values,zero(eltype(V)))
-  return dir_values
+  free_values = allocate_vector(V,get_free_dof_ids(f))
+  fill!(free_values,zero(eltype(V)))
+  return free_values
 end
 
 function get_vector_type(fs::FESpace)

--- a/src/FESpaces/SingleFieldFESpaces.jl
+++ b/src/FESpaces/SingleFieldFESpaces.jl
@@ -16,7 +16,9 @@ num_dirichlet_dofs(f::SingleFieldFESpace) = length(get_dirichlet_dof_ids(f))
 """
 function zero_dirichlet_values(f::SingleFieldFESpace)
   V = get_vector_type(f)
-  allocate_vector(V,num_dirichlet_dofs(f))
+  dir_values = allocate_vector(V,num_dirichlet_dofs(f))
+  fill!(dir_values,zero(eltype(V)))
+  return dir_values
 end
 
 """

--- a/src/FESpaces/UnconstrainedFESpaces.jl
+++ b/src/FESpaces/UnconstrainedFESpaces.jl
@@ -48,7 +48,6 @@ end
 
 ConstraintStyle(::Type{<:UnconstrainedFESpace}) = UnConstrained()
 get_free_dof_ids(f::UnconstrainedFESpace) = Base.OneTo(f.nfree)
-zero_free_values(f::UnconstrainedFESpace) = allocate_vector(f.vector_type,num_free_dofs(f))
 get_fe_basis(f::UnconstrainedFESpace) = f.fe_basis
 get_fe_dof_basis(f::UnconstrainedFESpace) = f.fe_dof_basis
 get_cell_dof_ids(f::UnconstrainedFESpace) = f.cell_dofs_ids
@@ -61,7 +60,6 @@ get_cell_is_dirichlet(f::UnconstrainedFESpace) = f.cell_is_dirichlet
 
 get_dirichlet_dof_ids(f::UnconstrainedFESpace) = Base.OneTo(f.ndirichlet)
 num_dirichlet_tags(f::UnconstrainedFESpace) = f.ntags
-zero_dirichlet_values(f::UnconstrainedFESpace) = allocate_vector(f.vector_type,num_dirichlet_dofs(f))
 get_dirichlet_dof_tag(f::UnconstrainedFESpace) = f.dirichlet_dof_tag
 
 function scatter_free_and_dirichlet_values(f::UnconstrainedFESpace,free_values,dirichlet_values)

--- a/src/MultiField/MultiFieldFESpaces.jl
+++ b/src/MultiField/MultiFieldFESpaces.jl
@@ -137,13 +137,6 @@ function FESpaces.get_free_dof_ids(f::MultiFieldFESpace,::BlockMultiFieldStyle{N
   return BlockArrays.blockedrange(block_num_dofs)
 end
 
-function FESpaces.zero_free_values(f::MultiFieldFESpace{<:BlockMultiFieldStyle{NB,SB,P}}) where {NB,SB,P}
-  block_ranges   = get_block_ranges(NB,SB,P)
-  block_num_dofs = map(range->sum(map(num_free_dofs,f.spaces[range])),block_ranges)
-  block_vtypes   = map(range->get_vector_type(first(f.spaces[range])),block_ranges)
-  return mortar(map(allocate_vector,block_vtypes,block_num_dofs))
-end
-
 FESpaces.get_dof_value_type(f::MultiFieldFESpace{MS,CS,V}) where {MS,CS,V} = eltype(V)
 
 FESpaces.get_vector_type(f::MultiFieldFESpace) = f.vector_type

--- a/src/ODEs/TransientFETools/TransientFESpaces.jl
+++ b/src/ODEs/TransientFETools/TransientFESpaces.jl
@@ -206,7 +206,9 @@ function zero_free_values(f::TransientMultiFieldTrialFESpace{<:BlockMultiFieldSt
   block_ranges   = get_block_ranges(NB,SB,P)
   block_num_dofs = map(range->sum(map(num_free_dofs,f.spaces[range])),block_ranges)
   block_vtypes   = map(range->get_vector_type(first(f.spaces[range])),block_ranges)
-  return mortar(map(allocate_vector,block_vtypes,block_num_dofs))
+  values = mortar(map(allocate_vector,block_vtypes,block_num_dofs))
+  fill!(values,zero(eltype(values)))
+  return values
 end
 
 get_dof_value_type(f::TransientMultiFieldTrialFESpace{MS,CS,V}) where {MS,CS,V} = eltype(V)


### PR DESCRIPTION
Up to now, `allocate_vector` used the `zeros` method to create the vector. This not only allocates, but also initializes. Now this is no longer the case. 

I have gone through the functions using `allocate_vector`, `allocate_in_domain` and `allocate_in_range` and did the necessary updates. 
Notably, the functions `zero_free_values` and `zero_dirichlet_values` were not explicitly filling the newly allocated vector with zeros, but were relying on the function to set the values to zero. This is now explicit. 

Also, now that the API for `allocate_vector` is more robust, I've gotten rid of some specializations for `zero_free_values` that are now redundant. 