### PR TITLE
Added missing methods for LagrangianDofBasis

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added `get_dof_to_node` and `get_dof_to_comp` for `LagrangianDofBasis`. Since PR[#964](https://github.com/gridap/Gridap.jl/pull/964).
+
 ### Changed
 
 - Changed how `allocate_vector` works. Now it only allocates, instead of allocating+initialising to zero. Since PR[#963](https://github.com/gridap/Gridap.jl/pull/963).

--- a/src/ReferenceFEs/LagrangianDofBases.jl
+++ b/src/ReferenceFEs/LagrangianDofBases.jl
@@ -55,6 +55,8 @@ function LagrangianDofBasis(::Type{T},nodes::Vector{<:Point}) where T
 end
 
 get_nodes(b::LagrangianDofBasis) = b.nodes
+get_dof_to_node(b::LagrangianDofBasis) = b.dof_to_node
+get_dof_to_comp(b::LagrangianDofBasis) = b.dof_to_comp
 
 function _generate_dof_layout_node_major(::Type{<:Real},nnodes::Integer)
   ndofs = nnodes


### PR DESCRIPTION
Added the methods `dof_to_node` and `dof_to_comp` for `LagragianDofBasis`. These methods already existed for lagrangian ReferenceFEs and were already exported. I'm just expanding them for the dof basis as well. 