### PR TITLE
Feature required to fix GridapDistributed.jl issue

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Changed how `symbolic_loop_matrix_vector!` loop works. Now it also takes account vector entries touched from matvecdata. Since PR[#975](https://github.com/gridap/Gridap.jl/pull/975).
+
 ## [0.17.22] - 2024-01-12
 
 ### Added

--- a/src/FESpaces/SparseMatrixAssemblers.jl
+++ b/src/FESpaces/SparseMatrixAssemblers.jl
@@ -289,11 +289,44 @@ end
 end
 
 function symbolic_loop_matrix_and_vector!(A,b,a::SparseMatrixAssembler,data)
+  if LoopStyle(A) == DoNotLoop()
+    return A, b
+  end
   matvecdata, matdata, vecdata = data
-  symbolic_loop_matrix!(A,a,matvecdata)
+  strategy = get_assembly_strategy(a)
+  for (cellmatvec,_cellidsrows,_cellidscols) in zip(matvecdata...)
+    cellidsrows = map_cell_rows(strategy,_cellidsrows)
+    cellidscols = map_cell_cols(strategy,_cellidscols)
+    @assert length(cellidscols) == length(cellidsrows)
+    @assert length(cellmatvec) == length(cellidsrows)
+    if length(cellmatvec) > 0
+      rows_cache = array_cache(cellidsrows)
+      cols_cache = array_cache(cellidscols)
+      vals_cache = array_cache(cellmatvec)
+      mat1, vec1 = getindex!(vals_cache,cellmatvec,1)
+      rows1 = getindex!(rows_cache,cellidsrows,1)
+      cols1 = getindex!(cols_cache,cellidscols,1)
+      touch! = TouchEntriesMap()
+      touch_mat_cache = return_cache(touch!,A,mat1,rows1,cols1)
+      touch_vec_cache = return_cache(touch!,b,vec1,rows1)
+      caches = touch_mat_cache, touch_vec_cache,rows_cache, cols_cache
+      _symbolic_loop_matvec!(A,b,caches,cellidsrows,cellidscols,mat1,vec1)
+    end
+  end
   symbolic_loop_matrix!(A,a,matdata)
   symbolic_loop_vector!(b,a,vecdata)
   A, b
+end 
+
+@noinline function _symbolic_loop_matvec!(A,b,caches,cell_rows,cell_cols,mat1,vec1)
+  touch_mat_cache, touch_vec_cache, rows_cache, cols_cache = caches
+  touch! = TouchEntriesMap()
+  for cell in 1:length(cell_cols)
+    rows = getindex!(rows_cache,cell_rows,cell)
+    cols = getindex!(cols_cache,cell_cols,cell)
+    evaluate!(touch_mat_cache,touch!,A,mat1,rows,cols)
+    evaluate!(touch_vec_cache,touch!,b,vec1,rows)
+  end
 end
 
 function numeric_loop_matrix_and_vector!(A,b,a::SparseMatrixAssembler,data)


### PR DESCRIPTION
Change the symbolic assembly loop for matrix_vector assembly such that it also takes into account the symbolic part corresponding to vector entries.

This is a feature required to fix issue 142 in gridapdistributed.jl

https://github.com/gridap/GridapDistributed.jl/issues/142