### PR TITLE
Bugfix: `restrict_to_field` creates copies for `BlockMultiFieldStyle`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.18.0] - 2024-03-22
+## [0.18.1] - 2024-04-12
+
+### Fixed
+
+- Bugfix in `restrict_to_field` for `BlockMultiFieldStyle`. Since PR[#993](https://github.com/gridap/Gridap.jl/pull/993).
+
+## [0.18.0] - 2024-04-12
 
 ### Breaking
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Gridap"
 uuid = "56d4f2e9-7ea1-5844-9cf6-b9c51ca7ce8e"
 authors = ["Santiago Badia <santiago.badia@monash.edu>", "Francesc Verdugo <f.verdugo.rojano@vu.nl>", "Alberto F. Martin <alberto.f.martin@anu.edu.au>"]
-version = "0.18.0"
+version = "0.18.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/MultiField/MultiFieldFESpaces.jl
+++ b/src/MultiField/MultiFieldFESpaces.jl
@@ -305,10 +305,12 @@ function  _restrict_to_field(f,::MultiFieldStyle,free_values,field)
   @notimplemented
 end
 
-function  _restrict_to_field(f,
-                             ::Union{<:ConsecutiveMultiFieldStyle,<:BlockMultiFieldStyle},
-                             free_values,
-                             field)
+function  _restrict_to_field(
+  f,
+  ::Union{<:ConsecutiveMultiFieldStyle,<:BlockMultiFieldStyle},
+  free_values,
+  field
+)
   U = f.spaces
   offsets = _compute_field_offsets(U)
   pini = offsets[field] + 1
@@ -316,17 +318,19 @@ function  _restrict_to_field(f,
   view(free_values,pini:pend)
 end
 
-function  _restrict_to_field(f,
-                             mfs::BlockMultiFieldStyle{NB,SB,P},
-                             free_values::BlockVector,
-                             field) where {NB,SB,P}
+function  _restrict_to_field(
+  f,
+  mfs::BlockMultiFieldStyle{NB,SB,P},
+  free_values::BlockVector,
+  field
+) where {NB,SB,P}
   @check blocklength(free_values) == NB
   U = f.spaces
 
   # Find the block for this field
   block_ranges = get_block_ranges(NB,SB,P)
   block_idx    = findfirst(range -> field ∈ range, block_ranges)
-  block_free_values = free_values[Block(block_idx)]
+  block_free_values = blocks(free_values)[block_idx]
 
   # Within the block, restrict to field
   offsets = compute_field_offsets(f,mfs)
@@ -596,7 +600,7 @@ function FESpaces.interpolate!(objects,free_values::AbstractVector,fe::MultiFiel
   blocks = SingleFieldFEFunction[]
   for (field, (U,object)) in enumerate(zip(fe.spaces,objects))
     free_values_i = restrict_to_field(fe,free_values,field)
-    uhi = interpolate!(object, free_values_i,U)
+    uhi = interpolate!(object, free_values_i, U)
     push!(blocks,uhi)
   end
   MultiFieldFEFunction(free_values,fe,blocks)


### PR DESCRIPTION
This is a fix for a bug created by the following PR: 

- https://github.com/JuliaLinearAlgebra/ArrayLayouts.jl/pull/219
- https://github.com/JuliaArrays/BlockArrays.jl/issues/236

The behavior of `x[Block(ib)]` changed, creating copies of the data. It's intentional, so we need to resolve it from our side.
