### PR TITLE
Add zero AffineMap helper

### DIFF
--- a/src/Fields/AffineMaps.jl
+++ b/src/Fields/AffineMaps.jl
@@ -108,3 +108,9 @@ function lazy_map(::typeof(∇),a::LazyArray{<:Fill{typeof(affine_map)}})
   gradients = a.args[1]
   lazy_map(constant_field,gradients)
 end
+
+function Base.zero(::Type{<:AffineMap{D1,D2,T}}) where {D1,D2,T}
+  gradient = TensorValue{D1,D2}(tfill(zero(T),Val{D1*D2}()))
+  origin = Point{D2,T}(tfill(zero(T),Val{D2}()))
+  AffineMap(gradient,origin)
+end

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -8,6 +8,7 @@ import Gridap.Arrays: testitem
 
 using Gridap.Helpers: @abstractmethod, @notimplemented
 using Gridap.Helpers: @notimplementedif, @unreachable, @check
+using Gridap.Helpers: tfill
 
 using Gridap.Algebra: mul!
 

--- a/test/FieldsTests/AffineMapsTests.jl
+++ b/test/FieldsTests/AffineMapsTests.jl
@@ -39,6 +39,9 @@ cell_to_∇hx = lazy_map(evaluate,cell_to_∇h,cell_to_x)
 test_array(cell_to_hx,fill(hx,ncells))
 test_array(cell_to_∇hx,fill(∇hx,ncells))
 
+T = AffineMap{3,3,Int}
+@test isa(zero(T),T)
+
 #display(cell_to_hx)
 #display(cell_to_∇hx)
 #print_op_tree(cell_to_hx)


### PR DESCRIPTION
@santiagobadia 

Adding a helper to define the type of arrays of affine maps. In particular, it is needed to integrate empty `DomainContribution()`


`zero(::Type{<:AffineMap})` 