### PR TITLE
Fix incorrect dof value type for linear constraints fe spaces

### DIFF
--- a/src/FESpaces/FESpacesWithLinearConstraints.jl
+++ b/src/FESpaces/FESpacesWithLinearConstraints.jl
@@ -470,6 +470,10 @@ function get_vector_type(f::FESpaceWithLinearConstraints)
   get_vector_type(f.space)
 end
 
+function get_dof_value_type(f::FESpaceWithLinearConstraints)
+  eltype(get_vector_type(f.space))
+end
+
 function get_fe_basis(f::FESpaceWithLinearConstraints)
   get_fe_basis(f.space)
 end

--- a/test/FESpacesTests/FESpacesWithLinearConstraintsTests.jl
+++ b/test/FESpacesTests/FESpacesWithLinearConstraintsTests.jl
@@ -46,14 +46,7 @@ Vc = FESpaceWithLinearConstraints(
 
 test_single_field_fe_space(Vc)
 @test has_constraints(Vc)
-@test get_dof_value_type(Vc) == ComplexF64 broken=true
-
-###################################################
-# One possible fix:
-import Gridap.FESpaces: get_dof_value_type
-get_dof_value_type(f::FESpaceWithLinearConstraints) = eltype(get_vector_type(f.space))
 @test get_dof_value_type(Vc) == ComplexF64
-###################################################
 
 @test isa(get_cell_constraints(Vc,Λ)[1],ArrayBlock)
 


### PR DESCRIPTION
When e.g. solving the Helmholtz equation we set `vector_type=Vector{ComplexF64}` for the `FESpace`, in that case we obtain correctly that `get_dof_value_type(V) == ComplexF64`.
When the space is a `FESpaceWithLinearConstraints` then `get_dof_value_type` incorrectly returns `Float64`; based on the default implementation in `FESpaceInterface.jl`.

My fix is to add
```Julia
get_dof_value_type(f::FESpaceWithLinearConstraints) = eltype(get_vector_type(f.space))
```
to `FESpacesWithLinearConstraints.jl`.

PS: It might be that the default implementation for `get_dof_value_type` in `FESpaceInterface.jl` is incorrect, as also for `V` a `FESpace` with `vector_type=Vector{ComplexF64}` I obtain `get_dof_value_type(get_fe_basis(V), get_fe_dof_basis(V)) == Float64` instead of `ComplexF64`.

I have extended the tests in `FESpacesWithLinearConstraintsTests.jl` to have `vector_type=Vector{ComplexF64}` and added appropriate tests. The first commit in this merge request just shows the current bug with `@test get_dof_value_type(Vc) == ComplexF64 broken=true` and then fixes the bug as above and runs the test again without the `broken=true`; the second commit corrects the bug in `FESpacesWithLinearConstraints.jl` and just leaves a `@test get_dof_value_type(Vc) == ComplexF64` in place.