### PR TITLE
Passing kwargs to simplexify refinement

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Passing `kwargs` from `refine` to `simplexify` functions in Adaptivity. Since PR[#1015](https://github.com/gridap/Gridap.jl/pull/1015).
+
 ## [0.18.3] - 2024-07-11
 
 ### Added

--- a/src/Adaptivity/AdaptedDiscreteModels.jl
+++ b/src/Adaptivity/AdaptedDiscreteModels.jl
@@ -2,9 +2,9 @@
 """
 
   `DiscreteModel` created by refining/coarsening another `DiscreteModel`.
-  
-  The refinement/coarsening hierarchy can be traced backwards by following the 
-  `parent` pointer chain. This allows the transfer of dofs 
+
+  The refinement/coarsening hierarchy can be traced backwards by following the
+  `parent` pointer chain. This allows the transfer of dofs
   between `FESpaces` defined on this model and its ancestors.
 
 """
@@ -77,7 +77,7 @@ end
 """
   function adapt(model::DiscreteModel,args...;kwargs...) :: AdaptedDiscreteModel
 
-  Returns an `AdaptedDiscreteModel` that is the result of adapting (mixed coarsening and refining) 
+  Returns an `AdaptedDiscreteModel` that is the result of adapting (mixed coarsening and refining)
   the given `DiscreteModel`.
 """
 function adapt(model::DiscreteModel,args...;kwargs...) :: AdaptedDiscreteModel
@@ -153,14 +153,14 @@ function _get_cartesian_domain(desc::CartesianDescriptor{D}) where D
   return Tuple(domain)
 end
 
-@generated function _c2v(idx::Union{NTuple{N,T},CartesianIndex{N}},sizes::NTuple{N,T}) where {N,T}    
+@generated function _c2v(idx::Union{NTuple{N,T},CartesianIndex{N}},sizes::NTuple{N,T}) where {N,T}
   res = :(idx[1])
   for d in 1:N-1
     ik = :((idx[$(d+1)]-1))
     for k in 1:d
         ik = :($ik * sizes[$k])
     end
-    res = :($res + $ik) 
+    res = :($res + $ik)
   end
   return res
 end
@@ -168,7 +168,7 @@ end
 @generated function _create_cartesian_f2c_maps(nC::NTuple{N,T},ref::NTuple{N,T}) where {N,T}
   J_f2c   = Meta.parse(prod(["(",["1+(I[$k]-1)÷ref[$k]," for k in 1:N]...,")"]))
   J_child = Meta.parse(prod(["(",["1+(I[$k]-1)%ref[$k]," for k in 1:N]...,")"]))
-  
+
   return :(begin
     nF = nC .* ref
     f2c_map   = Vector{Int}(undef,prod(nF))
@@ -180,7 +180,7 @@ end
       f2c_map[i] = _c2v(J_f2c,nC)
       child_map[i] = _c2v(J_child,ref)
     end
-        
+
     return f2c_map, child_map
   end)
 end

--- a/src/Adaptivity/SimplexifyRefinement.jl
+++ b/src/Adaptivity/SimplexifyRefinement.jl
@@ -2,7 +2,7 @@
 """
     struct SimplexifyRefinement <: AdaptivityMethod
 
-Equivalent to `simplexify`, but keeps track of the parent-child relationship between 
+Equivalent to `simplexify`, but keeps track of the parent-child relationship between
 the original and the refined model.
 """
 struct SimplexifyRefinement <: AdaptivityMethod end
@@ -14,7 +14,7 @@ function refine(::SimplexifyRefinement,model::UnstructuredDiscreteModel{Dc,Dp};k
   ctype = get_cell_type(model)
   rrules = expand_cell_data(map(p -> SimplexifyRefinementRule(p;kwargs...),polys),ctype)
   glue = blocked_refinement_glue(rrules)
-  
+
   return AdaptedDiscreteModel(ref_model,model,glue)
 end
 

--- a/src/Adaptivity/SimplexifyRefinement.jl
+++ b/src/Adaptivity/SimplexifyRefinement.jl
@@ -7,12 +7,12 @@ the original and the refined model.
 """
 struct SimplexifyRefinement <: AdaptivityMethod end
 
-function refine(::SimplexifyRefinement,model::UnstructuredDiscreteModel{Dc,Dp}) where {Dc,Dp}
-  ref_model = simplexify(model)
+function refine(::SimplexifyRefinement,model::UnstructuredDiscreteModel{Dc,Dp};kwargs...) where {Dc,Dp}
+  ref_model = simplexify(model;kwargs...)
 
   polys = get_polytopes(model)
   ctype = get_cell_type(model)
-  rrules = expand_cell_data(map(p -> SimplexifyRefinementRule(p),polys),ctype)
+  rrules = expand_cell_data(map(p -> SimplexifyRefinementRule(p;kwargs...),polys),ctype)
   glue = blocked_refinement_glue(rrules)
   
   return AdaptedDiscreteModel(ref_model,model,glue)
@@ -20,8 +20,8 @@ end
 
 struct SimplexifyRefinementRule <: RefinementRuleType end
 
-function SimplexifyRefinementRule(poly::Polytope)
-  conn, sp = simplexify(poly)
+function SimplexifyRefinementRule(poly::Polytope;kwargs...)
+  conn, sp = simplexify(poly;kwargs...)
   coords = get_vertex_coordinates(poly)
   reffes = [LagrangianRefFE(Float64,sp,1)]
   cell_types = fill(1,length(conn))

--- a/test/AdaptivityTests/EdgeBasedRefinementTests.jl
+++ b/test/AdaptivityTests/EdgeBasedRefinementTests.jl
@@ -107,7 +107,7 @@ visualize = false
 ############################################################################################
 ### Red-Green refinement
 
-## A) 2D meshes - QUADs 
+## A) 2D meshes - QUADs
 
 cart_model = CartesianDiscreteModel((0,1,0,1),(4,4))
 model1     = UnstructuredDiscreteModel(cart_model)

--- a/test/AdaptivityTests/EdgeBasedRefinementTests.jl
+++ b/test/AdaptivityTests/EdgeBasedRefinementTests.jl
@@ -229,4 +229,15 @@ trian17 = Triangulation(ref_model17.model)
 visualize && writevtk(trian17, "test/AdaptivityTests/ref_model17")
 test_grid_transfers(3, model3, ref_model17, 1)
 
+## C) 2D meshes - QUADs (Positive Volume)
+ref_model18 = refine(model1, refinement_method = "simplexify", positive = true)
+trian18 = Triangulation(ref_model18.model)
+visualize && writevtk(trian18, "test/AdaptivityTests/ref_model18")
+test_grid_transfers(2, model1, ref_model18, 1)
+
+## D) 3D meshes - HEXs (Positive Volume)
+ref_model19 = refine(model3, refinement_method = "simplexify", positive = true)
+trian19 = Triangulation(ref_model19.model)
+visualize && writevtk(trian19, "test/AdaptivityTests/ref_model19")
+test_grid_transfers(3, model3, ref_model19, 1)
 end


### PR DESCRIPTION
@santiagobadia @JordiManyer 

This PR passes the kwargs of refine to the simplexify core functions. In particular, it is tested for `positive=true`, which generates simplexified partitions with positive volume cells.