### PR TITLE
Add VTK encoding options

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Added WriteVTK kwargs to control the output encoding for vtk files. Since PR[#1016](https://github.com/gridap/Gridap.jl/pull/1016).
+
 ### Fixed
 
 - Passing `kwargs` from `refine` to `simplexify` functions in Adaptivity. Since PR[#1015](https://github.com/gridap/Gridap.jl/pull/1015).

--- a/test/VisualizationTests/VtkTests.jl
+++ b/test/VisualizationTests/VtkTests.jl
@@ -32,13 +32,15 @@ for compress in [true,false]
         write_vtk_file(
           trian,f,
           nodaldata=["nodeid"=>node_ids],
-          celldata=["cellid"=>cell_ids,"centers"=>cell_center]
+          celldata=["cellid"=>cell_ids,"centers"=>cell_center],
+          compress=compress, append=append, ascii=ascii, vtkversion=vtkversion
         )
 
         pvtk = Visualization.create_pvtk_file(
           trian,f; part=1, nparts=1,
           nodaldata=["nodeid"=>node_ids],
-          celldata=["cellid"=>cell_ids,"centers"=>cell_center]
+          celldata=["cellid"=>cell_ids,"centers"=>cell_center],
+          compress=compress, append=append, ascii=ascii, vtkversion=vtkversion
         )
         vtk_save(pvtk)
       end

--- a/test/VisualizationTests/VtkTests.jl
+++ b/test/VisualizationTests/VtkTests.jl
@@ -25,16 +25,26 @@ mean(x) = sum(x)/length(x)
 
 cell_center = lazy_map(mean, get_cell_coordinates(trian) )
 
-write_vtk_file(
-  trian,f,
-  nodaldata=["nodeid"=>node_ids],
-  celldata=["cellid"=>cell_ids,"centers"=>cell_center])
+for compress in [true,false]
+  for append in [true,false]
+    for ascii in [true,false]
+      for vtkversion in [:default,:latest]
+        write_vtk_file(
+          trian,f,
+          nodaldata=["nodeid"=>node_ids],
+          celldata=["cellid"=>cell_ids,"centers"=>cell_center]
+        )
 
-pvtk = Visualization.create_pvtk_file(
-  trian,f; part=1, nparts=1,
-  nodaldata=["nodeid"=>node_ids],
-  celldata=["cellid"=>cell_ids,"centers"=>cell_center])
-vtk_save(pvtk)
+        pvtk = Visualization.create_pvtk_file(
+          trian,f; part=1, nparts=1,
+          nodaldata=["nodeid"=>node_ids],
+          celldata=["cellid"=>cell_ids,"centers"=>cell_center]
+        )
+        vtk_save(pvtk)
+      end
+    end
+  end
+end
 
 reffe = LagrangianRefFE(VectorValue{3,Float64},WEDGE,(3,3,4))
 f = joinpath(d,"reffe")


### PR DESCRIPTION
Added options for setting the VTK encoding. Options follow the [WriteVTK.jl documentation](https://juliavtk.github.io/WriteVTK.jl/stable/grids/syntax/#Data-formatting-options).

