### PR TITLE
Improve performance of PR 967 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.5] - 2024-08-28 
+
+### Changed
+
+- Misc changes required to support facet integration on non-conforming meshes. These changes do not involve methods of the public API. Since PR[#967](https://github.com/gridap/Gridap.jl/pull/967)
+
 ## [0.18.4] - 2024-08-09
 
 ### Changed
@@ -77,7 +83,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Changed how `allocate_vector` works. Now it only allocates, instead of allocating+initialising to zero. Since PR[#963](https://github.com/gridap/Gridap.jl/pull/963).
-- Misc changes required to support facet integration on non-conforming meshes. These changes do not involve methods of the public API. Since PR[#967](https://github.com/gridap/Gridap.jl/pull/967)
 
 ### Fixed
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Gridap"
 uuid = "56d4f2e9-7ea1-5844-9cf6-b9c51ca7ce8e"
 authors = ["Santiago Badia <santiago.badia@monash.edu>", "Francesc Verdugo <f.verdugo.rojano@vu.nl>", "Alberto F. Martin <alberto.f.martin@anu.edu.au>"]
-version = "0.18.4"
+version = "0.18.5"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/Geometry/SkeletonTriangulations.jl
+++ b/src/Geometry/SkeletonTriangulations.jl
@@ -29,14 +29,18 @@ end
       minus::B
     end
 """
-struct SkeletonTriangulation{Dc,Dp,B} <: Triangulation{Dc,Dp}
+struct SkeletonTriangulation{Dc,Dp,B,C} <: Triangulation{Dc,Dp}
   plus::B
-  minus::B
-  function SkeletonTriangulation(plus::B,minus::B) where B<:Triangulation
-    Dc = num_cell_dims(plus)
-    Dp = num_point_dims(plus)
+  minus::C
+  function SkeletonTriangulation(plus::B,minus::C) where {B<:Triangulation,C<:Triangulation}
+    DcP = num_cell_dims(plus)
+    DpP = num_point_dims(plus)
+    DcM = num_cell_dims(minus)
+    DpP = num_point_dims(minus)
+    @assert DcP == DcM
+    @assert DpP == DpP
     #@assert Dc + 1 == Dp
-    new{Dc,Dp,B}(plus,minus)
+    new{DcP,DpP,B,C}(plus,minus)
   end
 end
 

--- a/test/GeometryTests/TriangulationsTests.jl
+++ b/test/GeometryTests/TriangulationsTests.jl
@@ -125,4 +125,10 @@ glue = get_glue(Ω2,Val(2))
 @test isa(glue.tface_to_mface,IdentityVector)
 @test isa(glue.mface_to_tface,IdentityVector)
 
+# Using a non-injective tface_to_mface map
+Ω3 = Triangulation(model, [1,2,1,2,3,3])
+glue = get_glue(Ω3,Val(2))
+@test isa(glue.tface_to_mface_map,Fill)
+@test isa(glue.mface_to_tface,Nothing)
+
 end # module


### PR DESCRIPTION
Performance optimization. The test on the injectivity of the tface_to_mface_map of BodyFittedTriangulation is moved to the BodyFittedTriangulation constructor, so that it is performed only once and not each time we call get_glue. Added a trait to BodyFittedTriangulation that stores the result of the test on injectivity.

Besides, for correctness, the mface_to_tface_map is set to nothing as currently PosNegPartition is not prepared to handle non-injective mappings. This will have to be replaced by a proper data structure that is able to handle non-injective mappings if in the future we find an scenario in which this inverse mapping is required to be used.