### PR TITLE
optimized MonomialBases evaluations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed #974, an error when weak form is real but unknown vector is complex. Since PR[#1050](https://github.com/gridap/Gridap.jl/pull/1050).
 - Fixed issue where barycentric refinement rule in 3D would not produce oriented meshes. Since PR[#1055](https://github.com/gridap/Gridap.jl/pull/1055).
 
+### Changed
+- Optimized MonomialBasis low-level functions. Since PR[#1059](https://github.com/gridap/Gridap.jl/pull/1059).
+
 ## [0.18.7] - 2024-10-8
 
 ### Added

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -2,3 +2,4 @@
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Gridap = "56d4f2e9-7ea1-5844-9cf6-b9c51ca7ce8e"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -12,3 +12,4 @@ end
 const SUITE = BenchmarkGroup()
 
 @include_bm SUITE "bm_assembly"
+@include_bm SUITE "bm_monomial_basis"

--- a/benchmark/bm/bm_monomial_basis.jl
+++ b/benchmark/bm/bm_monomial_basis.jl
@@ -1,0 +1,190 @@
+module bm_monomial_basis
+
+using PkgBenchmark, BenchmarkTools
+using Gridap
+using Gridap.Polynomials
+using Gridap.TensorValues
+using StaticArrays
+
+################################################
+# src/Polynomials/MonomialBasis.jl: _set_value_!
+################################################
+
+gradient_type = Gridap.Fields.gradient_type
+
+_set_value! = Gridap.Polynomials._set_value!
+
+function set_value_driver(f,T,D,x,n)
+  k = 1
+  s = one(T)
+  for i in 1:n
+    k = f(x,s,k)
+  end
+end
+
+function set_value_benchmarkable(D, T, V, n)
+  C = num_indep_components(V)
+  x = zeros(V,n*C)
+  return @benchmarkable set_value_driver($_set_value!,$T,$D,$x,$n)
+end
+
+##################################################
+# src/Polynomials/ModalC0Bases.jl: _set_value_mc0!
+##################################################
+
+_set_value_mc0! = Gridap.Polynomials._set_value_mc0!
+
+function set_value_mc0_driver(f,T,D,x,n)
+  k = 1
+  s = one(T)
+  for i in 1:n
+    k = f(x,s,k,2)
+  end
+end
+
+function set_value_mc0_benchmarkable(D, T, V, n)
+  C = num_indep_components(V)
+  x = zeros(V,2*n*C)
+  return @benchmarkable set_value_mc0_driver($_set_value_mc0!,$T,$D,$x,$n)
+end
+
+###################################################
+# src/Polynomials/MonomialBasis.jl: _set_gradient!
+###################################################
+
+ _set_gradient! = Gridap.Polynomials. _set_gradient!
+
+function set_gradient_driver(f,T,D,V,x,n)
+  k = 1
+  s = VectorValue{D,T}(ntuple(_->one(T),D))
+  for i in 1:n
+    k = f(x,s,k,V)
+  end
+end
+
+function set_gradient_benchmarkable(D, T, V, n)
+  C = num_indep_components(V)
+  G = gradient_type(V, zero(Point{D,T}))
+  x = zeros(G,n*C);
+  return @benchmarkable set_gradient_driver($_set_gradient!,$T,$D,$V,$x,$n)
+end
+
+#####################################################
+# src/Polynomials/ModalC0Bases.jl: _set_gradient_mc0!
+#####################################################
+
+ _set_gradient_mc0! = Gridap.Polynomials. _set_gradient_mc0!
+
+function set_gradient_mc0_driver(f,T,D,V,x,n)
+  k = 1
+  s = VectorValue{D,T}(ntuple(_->one(T),D))
+  for i in 1:n
+    k = f(x,s,k,1,V)
+  end
+end
+
+function set_gradient_mc0_benchmarkable(D, T, V, n)
+  C = num_indep_components(V)
+  G = gradient_type(V, zero(Point{D,T}))
+  x = zeros(G,n*C);
+  return @benchmarkable set_gradient_mc0_driver($_set_gradient_mc0!,$T,$D,$V,$x,$n)
+end
+
+#################################################
+# src/Polynomials/MonomialBasis.jl: _evaluate_1d!
+#################################################
+
+_evaluate_1d! = Gridap.Polynomials._evaluate_1d!
+
+function evaluate_1d_driver(f,order,D,v,x_vec)
+  for x in x_vec
+    f(v,x,order,D)
+  end
+end
+
+function evaluate_1d_benchmarkable(D, T, V, n)
+  n = Integer(n/50)
+  order = num_indep_components(V)
+  v = zeros(D,order+1);
+  x = rand(MVector{n,T})
+  return @benchmarkable evaluate_1d_driver($_evaluate_1d!,$order,$D,$v,$x)
+end
+
+################################################
+# src/Polynomials/MonomialBasis.jl:_gradient_1d!
+################################################
+
+_gradient_1d! = Gridap.Polynomials._gradient_1d!
+
+function gradient_1d_driver(f,order,D,v,x_vec)
+  for x in x_vec
+    f(v,x,order,D)
+  end
+end
+
+function gradient_1d_benchmarkable(D, T, V, n)
+  n = Integer(n/10)
+  order = num_indep_components(V)
+  v = zeros(D,order+1);
+  x = rand(MVector{n,T})
+  return @benchmarkable gradient_1d_driver($_gradient_1d!,$order,$D,$v,$x)
+end
+
+################################################
+# src/Polynomials/MonomialBasis.jl:_hessian_1d!
+################################################
+
+_hessian_1d! = Gridap.Polynomials._hessian_1d!
+
+function hessian_1d_driver(f,order,D,v,x_vec)
+  for x in x_vec
+    f(v,x,order,D)
+  end
+end
+
+function hessian_1d_benchmarkable(D, T, V, n)
+  n = Integer(n/10)
+  order = num_indep_components(V)
+  v = zeros(D,order+1);
+  x = rand(MVector{n,T})
+  return @benchmarkable hessian_1d_driver($_hessian_1d!,$order,$D,$v,$x)
+end
+
+#####################
+# benchmarkable suite
+#####################
+
+const SUITE = BenchmarkGroup()
+
+const benchmarkables = (
+  set_value_benchmarkable,
+  set_value_mc0_benchmarkable,
+  set_gradient_benchmarkable,
+  set_gradient_mc0_benchmarkable,
+  evaluate_1d_benchmarkable,
+  gradient_1d_benchmarkable,
+  hessian_1d_benchmarkable
+)
+
+const dims=(1, 2, 3, 5, 8)
+const n = 3000
+const T = Float64
+
+for benchable in benchmarkables
+  for D in dims
+    TV = [
+      VectorValue{D,T},
+      TensorValue{D,D,T,D*D},
+      SymTensorValue{D,T,Integer(D*(D+1)/2)},
+      SymTracelessTensorValue{D,T,Integer(D*(D+1)/2)}
+    ]
+
+    for V in TV
+      if V == SymTracelessTensorValue{1,T,1} continue end # no dofs
+      name = "monomial_basis_$(D)D_$(V)_$(benchable)"
+      SUITE[name] = benchable(D, T, V, n)
+    end
+  end
+end
+
+end # module


### PR DESCRIPTION
And added associated benchmark in ./benchmark.

I obtain the following speedup ranges on functions called with `VectorValue`'d, `TensorValue`'d, `SymTensorValue`'d and `SymTracelessTensorValue`'d FE basis for spatial dimensions 1,2,3 and 5:

```
                              # 1D     2D     3D     5D     
  set_value_benchmark        # ~67%   85:95% 40:85% 30:80% 
  set_gradient_benchmark     #  0:3%  5:35%  8:55%  37:100%
  set_value_mc0_benchmark    #  0%    80:99% 0:90%  0:60%   
  set_gradient_mc0_benchmark # 16:18% 27:36% 22:60% 38:100%
  evaluate_1d_benchmark      # ~80%   ~84%   80:90% 90:95%
  gradient_1d_benchmark      # 10:17% 38:55% 50:75% 70:85%
  hessian_1d_benchmark       # ~6%    0:60%  40:80% 60:90%
```