### PR TITLE
Implementation of `get_tangent_vector` with similar behavior as `get_normal_vector`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.10] - 2025-01-13
+
+### Added
+
+- Added corresponding function `get_tangent_vector` to `get_normal_vector`. This method calculates the (unique up to sign) tangential unit vector to edges in 2D meshes, by rotating the normal (nx, ny) -> (ny, -nx). Since PR[#1071](https://github.com/gridap/Gridap.jl/pull/1071).
+
 ## [0.18.9] - 2025-01-13
 
 

--- a/src/CellData/CellData.jl
+++ b/src/CellData/CellData.jl
@@ -61,6 +61,7 @@ export Integrand
 export ∫
 export CellDof
 export get_normal_vector
+export get_tangent_vector
 export get_cell_measure
 export Interpolable
 export KDTreeSearch

--- a/src/CellData/CellFields.jl
+++ b/src/CellData/CellFields.jl
@@ -112,13 +112,20 @@ function CellField(f,trian::Triangulation)
 end
 
 function get_normal_vector(trian::Triangulation)
+  println("Calling get_normal_vector")
   cell_normal = get_facet_normal(trian)
-  get_normal_vector(trian,cell_normal)
+  get_vector_skeleton_pair(trian,cell_normal, get_normal_vector)
 end
 
-function get_normal_vector(trian::Triangulation,cell_normal::AbstractArray)
-  GenericCellField(cell_normal,trian,ReferenceDomain())
+function get_tangent_vector(trian::Triangulation)
+  cell_tangent = get_edge_tangent(trian)
+  get_vector_skeleton_pair(trian,cell_tangent, get_edge_tangent)
 end
+
+function get_normal_vector(trian::Triangulation,cell_vectors::AbstractArray)
+  GenericCellField(cell_vectors,trian,ReferenceDomain())
+end
+
 
 evaluate!(cache,f::Function,x::CellPoint) = CellField(f,get_triangulation(x))(x)
 
@@ -706,9 +713,9 @@ function CellFieldAt{T}(parent::OperationCellField) where T
   OperationCellField(parent.op,args...)
 end
 
-function get_normal_vector(trian::Triangulation,cell_normal::SkeletonPair)
-  plus = get_normal_vector(trian,cell_normal.plus)
-  minus = get_normal_vector(trian,cell_normal.minus)
+function get_vector_skeleton_pair(trian::Triangulation,cell_normal::SkeletonPair, f::Function)
+  plus = f(trian,cell_normal.plus)
+  minus = f(trian,cell_normal.minus)
   SkeletonPair(plus,minus)
 end
 

--- a/src/CellData/CellFields.jl
+++ b/src/CellData/CellFields.jl
@@ -716,16 +716,14 @@ function CellFieldAt{T}(parent::OperationCellField) where T
 end
 
 function get_normal_vector(trian::Triangulation,cell_normal::SkeletonPair)
-  get_normal_or_tangent_vector(trian, cell_normal)
+  plus = get_normal_vector(trian,cell_normal.plus)
+  minus = get_normal_vector(trian,cell_normal.minus)
+  SkeletonPair(plus,minus)
 end
 
 function get_tangent_vector(trian::Triangulation,cell_tangent::SkeletonPair)
-  get_normal_or_tangent_vector(trian, cell_tangent)
-end
-
-function get_normal_or_tangent_vector(trian::Triangulation, cell::SkeletonPair)
-  plus = get_normal_vector(trian,cell.plus)
-  minus = get_normal_vector(trian,cell.minus)
+  plus = get_normal_vector(trian,cell_tangent.plus)
+  minus = get_normal_vector(trian,cell_tangent.minus)
   SkeletonPair(plus,minus)
 end
 

--- a/src/CellData/CellFields.jl
+++ b/src/CellData/CellFields.jl
@@ -112,20 +112,22 @@ function CellField(f,trian::Triangulation)
 end
 
 function get_normal_vector(trian::Triangulation)
-  println("Calling get_normal_vector")
   cell_normal = get_facet_normal(trian)
-  get_vector_skeleton_pair(trian,cell_normal, get_normal_vector)
+  get_normal_vector(trian, cell_normal)
 end
 
 function get_tangent_vector(trian::Triangulation)
   cell_tangent = get_edge_tangent(trian)
-  get_vector_skeleton_pair(trian,cell_tangent, get_edge_tangent)
+  get_tangent_vector(trian, cell_tangent)
 end
 
 function get_normal_vector(trian::Triangulation,cell_vectors::AbstractArray)
   GenericCellField(cell_vectors,trian,ReferenceDomain())
 end
 
+function get_tangent_vector(trian::Triangulation,cell_vectors::AbstractArray)
+  GenericCellField(cell_vectors,trian,ReferenceDomain())
+end
 
 evaluate!(cache,f::Function,x::CellPoint) = CellField(f,get_triangulation(x))(x)
 
@@ -713,9 +715,17 @@ function CellFieldAt{T}(parent::OperationCellField) where T
   OperationCellField(parent.op,args...)
 end
 
-function get_vector_skeleton_pair(trian::Triangulation,cell_normal::SkeletonPair, f::Function)
-  plus = f(trian,cell_normal.plus)
-  minus = f(trian,cell_normal.minus)
+function get_normal_vector(trian::Triangulation,cell_normal::SkeletonPair)
+  get_normal_or_tangent_vector(trian, cell_normal)
+end
+
+function get_tangent_vector(trian::Triangulation,cell_tangent::SkeletonPair)
+  get_normal_or_tangent_vector(trian, cell_tangent)
+end
+
+function get_normal_or_tangent_vector(trian::Triangulation, cell::SkeletonPair)
+  plus = get_normal_vector(trian,cell.plus)
+  minus = get_normal_vector(trian,cell.minus)
   SkeletonPair(plus,minus)
 end
 

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -141,6 +141,7 @@ using Gridap.TensorValues: ⊗; export ⊗
 @publish CellData mean
 @publish CellData update_state!
 @publish CellData get_normal_vector
+@publish CellData get_tangent_vector
 using Gridap.CellData: ∫; export ∫
 @publish CellData get_cell_measure
 @publish CellData get_physical_coordinate

--- a/src/Geometry/BoundaryTriangulations.jl
+++ b/src/Geometry/BoundaryTriangulations.jl
@@ -242,11 +242,7 @@ function get_edge_tangent(trian::BoundaryTriangulation, boundary_trian_glue::Fac
 
   face_s_n = get_facet_normal(trian, boundary_trian_glue)
 
-  function rotate_normal_2d(n)
-    t = VectorValue(n[2], -n[1])
-    m = sqrt(t[1]^2 + t[2]^2)
-    return m < eps() ? VectorValue(0.0, 0.0) : t
-  end
+  rotate_normal_2d(n) = VectorValue(n[2], -n[1])
 
   face_s_t = lazy_map(Operation(rotate_normal_2d), face_s_n)
 

--- a/src/Geometry/BoundaryTriangulations.jl
+++ b/src/Geometry/BoundaryTriangulations.jl
@@ -239,17 +239,14 @@ function get_facet_normal(trian::BoundaryTriangulation, boundary_trian_glue::Fac
 end
 
 function get_edge_tangent(trian::BoundaryTriangulation, boundary_trian_glue::FaceToCellGlue)
-  # 1) Retrieve the cell grid from the boundary triangulation
   cell_grid = get_grid(get_background_model(trian.trian))
 
-  # 2) Define how we get reference tangents for each local face
+  ## Reference tangent
   function f(r)
     p = get_polytope(r)
     lface_to_t = get_edge_tangent(p)
-
     lface_to_pindex_to_perm = get_face_vertex_permutations(p, num_cell_dims(p)-1)
     nlfaces = length(lface_to_t)
-
     # Repeat tangents according to the permutations, just like normals
     lface_pindex_to_t = [
       fill(lface_to_t[lface], length(lface_to_pindex_to_perm[lface]))
@@ -257,32 +254,22 @@ function get_edge_tangent(trian::BoundaryTriangulation, boundary_trian_glue::Fac
     ]
     return lface_pindex_to_t
   end
-
-  # 3) Map the function f over all reference polytope types
   ctype_lface_pindex_to_tref = map(f, get_reffes(cell_grid))
-
-  # 4) Convert into a FaceCompressedVector
   face_to_tref = FaceCompressedVector(ctype_lface_pindex_to_tref, boundary_trian_glue)
-
-  # 5) Mark it as a constant field on each facet
   face_s_tref = lazy_map(constant_field, face_to_tref)
 
-  # 6) Geometric transformation from reference to real domain
+  # Tangent vectors transform like the Jacobian
   cell_q_x = get_cell_map(cell_grid)
   cell_q_Jt = lazy_map(∇, cell_q_x)
-  face_q_Jt = lazy_map(Reindex(cell_q_Jt), boundary_trian_glue.face_to_cell)
-  face_q_J  = lazy_map(transpose, face_q_Jt) 
-
-  # 7) Get dimension, get glue
+  cell_q_J  = lazy_map(Operation(transpose), cell_q_Jt) 
+  face_q_J = lazy_map(Reindex(cell_q_J), boundary_trian_glue.face_to_cell)
+  
+  # Change of domain
   D = num_cell_dims(cell_grid)
   boundary_trian_glue_D = get_glue(trian, Val(D))
   face_s_q = boundary_trian_glue_D.tface_to_mface_map
   face_s_J = lazy_map(∘, face_q_J, face_s_q)
-
-  # 8) Push the reference tangent to physical domain
   face_s_t = lazy_map(Broadcasting(Operation(push_tangent)), face_s_J, face_s_tref)
-
-  # 9) Memoize
   return Fields.MemoArray(face_s_t)
 end
 

--- a/src/Geometry/Geometry.jl
+++ b/src/Geometry/Geometry.jl
@@ -70,6 +70,7 @@ import Gridap.ReferenceFEs: num_cell_dims
 import Gridap.ReferenceFEs: num_point_dims
 import Gridap.ReferenceFEs: simplexify
 import Gridap.ReferenceFEs: get_facet_normal
+import Gridap.ReferenceFEs: get_edge_tangent
 import Gridap.ReferenceFEs: Quadrature
 
 export GridTopology
@@ -107,6 +108,7 @@ export get_cell_ref_coordinates
 export get_cell_reffe
 export get_cell_shapefuns
 export get_facet_normal
+export get_edge_tangent
 export test_triangulation
 export get_cell_map
 

--- a/src/Geometry/SkeletonTriangulations.jl
+++ b/src/Geometry/SkeletonTriangulations.jl
@@ -94,6 +94,12 @@ function get_facet_normal(trian::SkeletonTriangulation)
   SkeletonPair(plus,minus)
 end
 
+function get_edge_tangent(trian::SkeletonTriangulation)
+  plus = get_edge_tangent(trian.plus)
+  minus = get_edge_tangent(trian.minus)
+  SkeletonPair(plus,minus)
+end
+
 # Related with CompositeTriangulation
 function _compose_glues(rglue::FaceToFaceGlue,dglue::SkeletonPair)
   plus = _compose_glues(rglue,dglue.plus)

--- a/src/Geometry/SkeletonTriangulations.jl
+++ b/src/Geometry/SkeletonTriangulations.jl
@@ -96,8 +96,7 @@ end
 
 function get_edge_tangent(trian::SkeletonTriangulation)
   plus = get_edge_tangent(trian.plus)
-  # Flip the minus side
-  minus = lazy_map(x -> -x, plus)
+  minus = get_edge_tangent(trian.minus)
   SkeletonPair(plus,minus)
 end
 

--- a/src/Geometry/SkeletonTriangulations.jl
+++ b/src/Geometry/SkeletonTriangulations.jl
@@ -96,7 +96,8 @@ end
 
 function get_edge_tangent(trian::SkeletonTriangulation)
   plus = get_edge_tangent(trian.plus)
-  minus = get_edge_tangent(trian.minus)
+  # Flip the minus side
+  minus = lazy_map(x -> -x, plus)
   SkeletonPair(plus,minus)
 end
 

--- a/src/Geometry/Triangulations.jl
+++ b/src/Geometry/Triangulations.jl
@@ -41,6 +41,7 @@ get_cell_node_ids(trian::Triangulation) = get_cell_node_ids(get_grid(trian))
 get_reffes(trian::Triangulation) = get_reffes(get_grid(trian))
 get_cell_type(trian::Triangulation) = get_cell_type(get_grid(trian))
 get_facet_normal(trian::Triangulation) = get_facet_normal(get_grid(trian))
+get_edge_tangent(trian::Triangulation) = get_edge_tangent(get_grid(trian))
 
 # The following are not strictly needed, sine there is a default implementation for them.
 # In any case, we delegate just in case the underlying grid defines more performant versions

--- a/src/Geometry/Triangulations.jl
+++ b/src/Geometry/Triangulations.jl
@@ -41,7 +41,6 @@ get_cell_node_ids(trian::Triangulation) = get_cell_node_ids(get_grid(trian))
 get_reffes(trian::Triangulation) = get_reffes(get_grid(trian))
 get_cell_type(trian::Triangulation) = get_cell_type(get_grid(trian))
 get_facet_normal(trian::Triangulation) = get_facet_normal(get_grid(trian))
-get_edge_tangent(trian::Triangulation) = get_edge_tangent(get_grid(trian))
 
 # The following are not strictly needed, sine there is a default implementation for them.
 # In any case, we delegate just in case the underlying grid defines more performant versions

--- a/test/GeometryTests/BoundaryTriangulationsTests.jl
+++ b/test/GeometryTests/BoundaryTriangulationsTests.jl
@@ -110,6 +110,11 @@ face_to_nvec_s = lazy_map(evaluate,face_to_nvec,face_to_s)
 test_array(face_to_nvec_s,collect(face_to_nvec_s))
 @test isa(face_to_nvec_s,Geometry.FaceCompressedVector)
 
+face_to_tvec = get_edge_tangent(btrian)
+face_to_tvec_s = lazy_map(evaluate,face_to_tvec,face_to_s)
+test_array(face_to_tvec_s,collect(face_to_tvec_s))
+@test isa(face_to_tvec_s,Geometry.FaceCompressedVector)
+
 #print_op_tree(face_shapefuns_q)
 #print_op_tree(face_grad_shapefuns_q)
 #print_op_tree(face_to_nvec_s)
@@ -146,6 +151,16 @@ r = Vector{Point{2,Float64}}[
   [(0.0,1.0),(0.0,1.0)],[(-1.0,0.0),(-1.0,0.0)],
   [(0.0,1.0),(0.0,1.0)],[(1.0,-0.0),(1.0,-0.0)]]
 test_array(nvec_s,r)
+
+tvec = get_edge_tangent(btrian)
+
+tvec_s = lazy_map(evaluate,tvec,s)
+
+rotate_90(x) = [Point(x[1][2], -x[1][1]), Point(x[2][2], -x[2][1])]
+
+rr = rotate_90.(r)
+
+test_array(rr, tvec_s)
 
 cellids = collect(1:num_cells(model))
 

--- a/test/GeometryTests/SkeletonTriangulationsTests.jl
+++ b/test/GeometryTests/SkeletonTriangulationsTests.jl
@@ -112,6 +112,14 @@ itrian = InterfaceTriangulation(Ω_in,Ω_out)
 #writevtk(trian,"trian",celldata=["inout"=>cell_to_inout])
 #writevtk(itrian,"itrian",nsubcells=10,cellfields=["ni"=>ni,"nl"=>nl,"nr"=>nr])
 
+ti = get_tangent_vector(itrian)
+tl = get_tangent_vector(ltrian)
+tr = get_tangent_vector(rtrian)
+
+@test ti isa SkeletonPair
+@test tl isa Gridap.CellData.GenericCellField
+@test tr isa Gridap.CellData.GenericCellField 
+
 reffe = LagrangianRefFE(Float64,QUAD,(2,2))
 conf = CDConformity((CONT,DISC))
 face_own_dofs = get_face_own_dofs(reffe,conf)

--- a/test/GeometryTests/SkeletonTriangulationsTests.jl
+++ b/test/GeometryTests/SkeletonTriangulationsTests.jl
@@ -46,7 +46,7 @@ vglue = get_glue(vtrian,Val(3))
 @test vglue.plus.tface_to_mface == sglue.plus.tface_to_mface[ids]
 @test vglue.minus.tface_to_mface == sglue.minus.tface_to_mface[ids]
 vn = get_facet_normal(vtrian)
-vt = Gridap.Geometry.get_edge_tangent(strian)
+# vt = Gridap.Geometry.get_edge_tangent(strian)
 @test isa(vn,SkeletonPair)
 @test isa(vn.plus,AbstractArray)
 @test isa(vn.minus,AbstractArray)

--- a/test/GeometryTests/SkeletonTriangulationsTests.jl
+++ b/test/GeometryTests/SkeletonTriangulationsTests.jl
@@ -46,7 +46,6 @@ vglue = get_glue(vtrian,Val(3))
 @test vglue.plus.tface_to_mface == sglue.plus.tface_to_mface[ids]
 @test vglue.minus.tface_to_mface == sglue.minus.tface_to_mface[ids]
 vn = get_facet_normal(vtrian)
-# vt = Gridap.Geometry.get_edge_tangent(strian)
 @test isa(vn,SkeletonPair)
 @test isa(vn.plus,AbstractArray)
 @test isa(vn.minus,AbstractArray)
@@ -119,7 +118,13 @@ face_own_dofs = get_face_own_dofs(reffe,conf)
 strian = SkeletonTriangulation(model,reffe,face_own_dofs)
 test_triangulation(strian)
 ns = get_facet_normal(strian)
+ts = get_edge_tangent(strian)
 @test length(ns.⁺) == num_cells(strian)
+@test length(ts.⁺) == num_cells(strian)
+# Test orthogonality
+should_be_zero = lazy_map(Broadcasting(Operation(dot)), ns.plus, ts.plus)
+ndot_t_evaluated = evaluate(should_be_zero, VectorValue.(0:0.05:1))
+@test maximum(ndot_t_evaluated) < 1e-15
 
 #using Gridap.Visualization
 #writevtk(strian,"strian",cellfields=["normal"=>ns])

--- a/test/GeometryTests/SkeletonTriangulationsTests.jl
+++ b/test/GeometryTests/SkeletonTriangulationsTests.jl
@@ -1,6 +1,7 @@
 module SkeletonTriangulationsTests
 
 using Test
+using Gridap
 using Gridap.TensorValues
 using Gridap.Arrays
 using Gridap.Fields
@@ -45,6 +46,7 @@ vglue = get_glue(vtrian,Val(3))
 @test vglue.plus.tface_to_mface == sglue.plus.tface_to_mface[ids]
 @test vglue.minus.tface_to_mface == sglue.minus.tface_to_mface[ids]
 vn = get_facet_normal(vtrian)
+vt = Gridap.Geometry.get_edge_tangent(strian)
 @test isa(vn,SkeletonPair)
 @test isa(vn.plus,AbstractArray)
 @test isa(vn.minus,AbstractArray)
@@ -52,6 +54,7 @@ vn = get_facet_normal(vtrian)
 Ω = Triangulation(model)
 Γ = BoundaryTriangulation(model)
 Λ = SkeletonTriangulation(Γ)
+normal = get_normal_vector(Λ)
 @test Λ.rtrian === Γ
 @test isa(Λ.dtrian,SkeletonTriangulation)
 glue = get_glue(Λ,Val(3))


### PR DESCRIPTION
My motivation for the PR came from the desire to implement a DG scheme for vector value problems with jumping tangential components, e.g.

![jump_tangent](https://github.com/user-attachments/assets/70cf6b12-ea7c-478c-b68d-d3caf8c69888)

where the tangent and normal are define schematically via

![schema_jump_tangent](https://github.com/user-attachments/assets/b3c257c7-576a-44de-90ea-197da51187a7)

I followed the outline I found for `get_normal_vector` that works for both `SkeletonTrianguations` and `BoundaryTriangulations` but instead of using `get_facet_normal` I used `get_edge_tangent` for the underlying `Polytope`. 

Here are the resulting normal (resp. tangent) cell fields for a `BoundaryTriangulation`
![normal](https://github.com/user-attachments/assets/1b62946b-027f-4256-85d8-69b37f30f839)
![tangent](https://github.com/user-attachments/assets/8740c1a1-519b-4aca-9d16-c4e89287d4d9)

And idem for the `plus` component of a `SkeletonTriangulation`
![normal_skel](https://github.com/user-attachments/assets/49d67fbe-1168-4f63-920b-a54141fce82c)
![tangent_skel](https://github.com/user-attachments/assets/9a4df507-89f9-4f3e-a78c-d8cf7b5ae2cc)

I still need to add some tests in the spirit of those in `SkeletonTriangulationTests` and `BoundaryTriangulationTests` but I wanted to make this PR first and get some feedback. I also think there could probably be a more elegant way to unify the logic of `get_normal_vector` and `get_tangent_vector` to reduce code duplication but this would also probably obfuscate the code a bit.