### PR TITLE
Fixed a BUG in Arrays.evaluate!(cache,a::FineToCoarseField,x::AbstractArray{<:Point})

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Fixed
+
+- BUG in `FineToCoarseFields.jl`. Since PR[#1074](https://github.com/gridap/Gridap.jl/pull/1074)
+
 ### Added
 
 - Added AMR-related methods `mark` and `estimate` to `Adaptivity` module. Implemented Dorfler marking strategy. Since PR[#1063](https://github.com/gridap/Gridap.jl/pull/1063).

--- a/src/Adaptivity/FineToCoarseFields.jl
+++ b/src/Adaptivity/FineToCoarseFields.jl
@@ -108,7 +108,7 @@ function Arrays.evaluate!(cache,a::FineToCoarseField,x::AbstractArray{<:Point})
     field_id = id_map[child_id]
     if field_id != 0
       fi = getindex!(fi_cache,fields,field_id)
-      mi = getindex!(mi_cache,cmaps,field_id)
+      mi = getindex!(mi_cache,cmaps,child_id)
       zi = Fields.evaluate!(zi_cache,mi,xi)
       y[i] = Fields.evaluate!(yi_cache,fi,zi)
     end

--- a/test/AdaptivityTests/FineToCoarseFieldsTests.jl
+++ b/test/AdaptivityTests/FineToCoarseFieldsTests.jl
@@ -100,4 +100,91 @@ xHh = change_domain(xH,get_triangulation(modelh),ReferenceDomain())
 evaluate(Gridap.CellData.get_data(xHh)[1],[Point(0.0,0.0),Point(0.5,0.5)])
 evaluate(Gridap.CellData.get_data(xHh)[1],Point(0.5,0.5))
 
+function test_PR_1074()
+
+    function setup_coarse_discrete_model()
+        ptr  = [ 1, 5 ]
+        data = [ 1,2,3,4  ]
+        cell_vertex_lids = Gridap.Arrays.Table(data,ptr)
+        node_coordinates = Vector{Point{2,Float64}}(undef,4)
+        node_coordinates[1]=Point{2,Float64}(0.0,0.0)
+        node_coordinates[2]=Point{2,Float64}(1.0,0.0)
+        node_coordinates[3]=Point{2,Float64}(0.0,1.0)
+        node_coordinates[4]=Point{2,Float64}(1.0,1.0)
+
+        polytope=QUAD
+        scalar_reffe=Gridap.ReferenceFEs.ReferenceFE(polytope,Gridap.ReferenceFEs.lagrangian,Float64,1)
+        cell_types=collect(Fill(1,length(cell_vertex_lids)))
+        cell_reffes=[scalar_reffe]
+        grid = Gridap.Geometry.UnstructuredGrid(node_coordinates,
+                                                cell_vertex_lids,
+                                                cell_reffes,
+                                                cell_types,
+                                                Gridap.Geometry.NonOriented())
+        Gridap.Geometry.UnstructuredDiscreteModel(grid)
+    end
+
+    function setup_adapted_discrete_model(parent)
+        ptr  = [ 1, 5, 9 ]
+        data = [ 1,2,3,4, 2,5,4,6 ] 
+        cell_vertex_lids = Gridap.Arrays.Table(data,ptr)
+        node_coordinates = Vector{Point{2,Float64}}(undef,6)
+        node_coordinates[1]=Point{2,Float64}(0.0,0.5)
+        node_coordinates[2]=Point{2,Float64}(0.5,0.5)
+        node_coordinates[3]=Point{2,Float64}(0.0,1.0)
+        node_coordinates[4]=Point{2,Float64}(0.5,1.0)
+        node_coordinates[5]=Point{2,Float64}(1.0,0.5)
+        node_coordinates[6]=Point{2,Float64}(1.0,1.0)
+
+        polytope=QUAD
+        scalar_reffe=Gridap.ReferenceFEs.ReferenceFE(polytope,Gridap.ReferenceFEs.lagrangian,Float64,1)
+        cell_types=collect(Fill(1,length(cell_vertex_lids)))
+        cell_reffes=[scalar_reffe]
+        grid = Gridap.Geometry.UnstructuredGrid(node_coordinates,
+                                                cell_vertex_lids,
+                                                cell_reffes,
+                                                cell_types,
+                                                Gridap.Geometry.NonOriented())
+        model=Gridap.Geometry.UnstructuredDiscreteModel(grid)
+
+        n2o_faces_map=Vector{Vector{Int64}}(undef,3)
+        n2o_faces_map[3]=[1,1]
+        n2o_cell_to_child_id=[2,3]
+        
+        ref_rules = [Gridap.Adaptivity.RefinementRule(Gridap.ReferenceFEs.LagrangianRefFE(Float64,QUAD,1),2)]
+
+        glue=Gridap.Adaptivity.AdaptivityGlue(Gridap.Adaptivity.RefinementGlue(),
+                                        n2o_faces_map,
+                                        n2o_cell_to_child_id,
+                                        ref_rules)
+        Gridap.Adaptivity.AdaptedDiscreteModel(model,parent,glue)
+    end
+
+    coarse_model=setup_coarse_discrete_model()
+    fine_model=setup_adapted_discrete_model(coarse_model)
+
+    order=0
+
+    VH = FESpace(coarse_model,
+                ReferenceFE(raviart_thomas,Float64,order),
+                conformity=:Hdiv)
+
+    UH = TrialFESpace(VH)
+        
+    Vh = FESpace(fine_model,
+                ReferenceFE(raviart_thomas,Float64,order),
+                conformity=:Hdiv)
+        
+    Uh = TrialFESpace(Vh)
+
+    u(x) = VectorValue(x[1],x[2])
+    uh  = interpolate(u,Uh)
+    uH  = interpolate(u,UH)
+    uhH = interpolate(uh,UH) 
+
+    @test get_free_dof_values(uhH)[2] ≈ 1.0
+end
+
+test_PR_1074()
+
 end


### PR DESCRIPTION
It was spotted whenever id_map is not the identity map, e.g., [0 0 1 2] This is in turn triggered from GridapP4est whenever a ghost parent cell in a processor does not have all children cells on its local portion