### PR TITLE
Allow real and imag functions to return real TensorValue

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.11]
+
+### Changed
+
+- `real` and `imag` functions now return a real TensorValue. Since PR[#1080](https://github.com/gridap/Gridap.jl/pull/1080)
+
 ## [0.18.10] - 2025-01-13
 
 ### Added

--- a/src/TensorValues/Operations.jl
+++ b/src/TensorValues/Operations.jl
@@ -196,6 +196,22 @@ end
   typeof(reduce(op,zero.(eltype.(a))))
 end
 
+@inline function _eltype(op,r,a,b)
+  eltype(r)
+end
+
+@inline function _eltype(op,r::Tuple{},a,b)
+  typeof(op(zero(eltype(a)),zero(eltype(b))))
+end
+
+@inline function _eltype(op,r,a)
+  eltype(r)
+end
+
+@inline function _eltype(op,r::Tuple{},a)
+  typeof(op(zero(eltype(a))))
+end
+
 ###############################################################
 # Dot product (simple contraction)
 ###############################################################

--- a/src/TensorValues/Operations.jl
+++ b/src/TensorValues/Operations.jl
@@ -188,12 +188,12 @@ function -(::SymTracelessTensorValue,::MultiValue) error("Subtraction"*_err) end
 function +(::MultiValue,::SymTracelessTensorValue) error("Addition"   *_err) end
 function -(::MultiValue,::SymTracelessTensorValue) error("Subtraction"*_err) end
 
-@inline function _eltype(op,r,a,b)
+@inline function _eltype(op,r,a...)
   eltype(r)
 end
 
-@inline function _eltype(op,r::Tuple{},a,b)
-  typeof(op(zero(eltype(a)),zero(eltype(b))))
+@inline function _eltype(op,r::Tuple{},a...)
+  typeof(reduce(op,zero.(eltype.(a))))
 end
 
 ###############################################################
@@ -760,12 +760,16 @@ for op in (:conj,:real,:imag)
   @eval begin
     function ($op)(a::T) where {T<:MultiValue}
       r = map($op, a.data)
-      T(r)
+      T2 = _eltype($op,r,a)
+      M  = change_eltype(a,T2)
+      M(r)
     end
 
     function ($op)(a::SymTracelessTensorValue)
       r = map($op, a.data)
-      SymTracelessTensorValue(r[1:end-1])
+      T2 = _eltype($op,r,a)
+      M  = change_eltype(a,T2)
+      M(r[1:end-1])
     end
   end
 end

--- a/test/TensorValuesTests/OperationsTests.jl
+++ b/test/TensorValuesTests/OperationsTests.jl
@@ -1029,17 +1029,40 @@ b = 4.0 - 3.0*im
 @test outer(a,b) == a*b
 @test inner(a,b) == a*b
 
-@test real(VectorValue(1+1im)) == VectorValue(1)
-@test real(VectorValue(1+1im, 1+1im)) == VectorValue(1, 1)
-@test real(VectorValue(1+1im, 1+1im, 1+1im)) == VectorValue(1, 1, 1)
-@test real(TensorValue(1+1im, 1+1im, 1+1im, 1+1im)) == TensorValue(1, 1, 1, 1)
-@test real(SymTracelessTensorValue(1+1im, 1+1im)) == SymTracelessTensorValue(1, 1)
+v1 = VectorValue(1+1im)
+v2 = VectorValue(1)
+@test real(v1) == v2 && eltype(real(v1)) == eltype(v2)
+@test imag(v1) == v2 && eltype(imag(v1)) == eltype(v2)
+v2 = VectorValue(1-1im)
+@test conj(v1) == v2 && eltype(conj(v1)) == eltype(v2)
 
-@test imag(VectorValue(1+1im)) == VectorValue(1)
-@test imag(VectorValue(1+1im, 1+1im)) == VectorValue(1, 1)
-@test imag(VectorValue(1+1im, 1+1im, 1+1im)) == VectorValue(1, 1, 1)
-@test imag(TensorValue(1+1im, 1+1im, 1+1im, 1+1im)) == TensorValue(1, 1, 1, 1)
-@test imag(SymTracelessTensorValue(1+1im, 1+1im)) == SymTracelessTensorValue(1, 1)
+v1 = VectorValue(1+1im, 1+1im)
+v2 = VectorValue(1, 1)
+@test real(v1) == v2 && eltype(real(v1)) == eltype(v2)
+@test imag(v1) == v2 && eltype(imag(v1)) == eltype(v2)
+v2 = VectorValue(1-1im, 1-1im)
+@test conj(v1) == v2 && eltype(conj(v1)) == eltype(v2)
+
+v1 = VectorValue(1+1im, 1+1im, 1+1im)
+v2 = VectorValue(1, 1, 1)
+@test real(v1) == v2 && eltype(real(v1)) == eltype(v2)
+@test imag(v1) == v2 && eltype(imag(v1)) == eltype(v2)
+v2 = VectorValue(1-1im, 1-1im, 1-1im)
+@test conj(v1) == v2 && eltype(conj(v1)) == eltype(v2)
+
+v1 = TensorValue(1+1im, 1+1im, 1+1im, 1+1im)
+v2 = TensorValue(1, 1, 1, 1)
+@test real(v1) == v2 && eltype(real(v1)) == eltype(v2)
+@test imag(v1) == v2 && eltype(imag(v1)) == eltype(v2)
+v2 = TensorValue(1-1im, 1-1im, 1-1im, 1-1im)
+@test conj(v1) == v2 && eltype(conj(v1)) == eltype(v2)
+
+v1 = SymTracelessTensorValue(1+1im, 1+1im)
+v2 = SymTracelessTensorValue(1, 1)
+@test real(v1) == v2 && eltype(real(v1)) == eltype(v2)
+@test imag(v1) == v2 && eltype(imag(v1)) == eltype(v2)
+v2 = SymTracelessTensorValue(1-1im, 1-1im)
+@test conj(v1) == v2 && eltype(conj(v1)) == eltype(v2)
 
 # Broadcast
 a = VectorValue(1,2,3)

--- a/test/TensorValuesTests/OperationsTests.jl
+++ b/test/TensorValuesTests/OperationsTests.jl
@@ -5,6 +5,7 @@ using Test
 using Gridap.TensorValues
 using Gridap.Arrays
 using LinearAlgebra
+using Gridap.TensorValues: _eltype
 
 # Comparison
 
@@ -1063,6 +1064,12 @@ v2 = SymTracelessTensorValue(1, 1)
 @test imag(v1) == v2 && eltype(imag(v1)) == eltype(v2)
 v2 = SymTracelessTensorValue(1-1im, 1-1im)
 @test conj(v1) == v2 && eltype(conj(v1)) == eltype(v2)
+
+#_eltype
+@test _eltype(real,Tuple{},VectorValue(1.0,2.0))==Union{}
+@test _eltype(real,Tuple{},VectorValue(1.0,2.0),VectorValue(2.0,3.0),VectorValue(3.0,4.0))==Union{}
+a=VectorValue(4.0,5.0)
+@test _eltype(real,a,VectorValue(1.0,2.0+im),VectorValue(2.0,3.0),VectorValue(3.0,4.0))==eltype(a)
 
 # Broadcast
 a = VectorValue(1,2,3)


### PR DESCRIPTION
This small PR allows the `real` and `imag` functions to return real results like the base Julia functions

```julia
real(TensorValue(1.0+2im,2.0+3im,3.0+4im,4.0+5im))
```
returns
- Without the PR:
```julia
TensorValue{2, 2, ComplexF64, 4}(1.0 + 0.0im, 2.0 + 0.0im, 3.0 + 0.0im, 4.0 + 0.0im)
```
- With the PR:
```julia
TensorValue{2, 2, Float64, 4}(1.0, 2.0, 3.0, 4.0)
```


