### PR TITLE
Added constructors for DiracDelta with Triangulation argument.

### DIFF
--- a/src/CellData/DiracDeltas.jl
+++ b/src/CellData/DiracDeltas.jl
@@ -118,3 +118,28 @@ function DiracDelta(model::DiscreteModel{D}, pvec::Vector{Point{D,T}}) where {D,
   pmeas = Measure(CellQuadrature(pquad,points,weights_x_cell,trianv,PhysicalDomain(),PhysicalDomain()))
   GenericDiracDelta{0,D,NotGridEntity}(trianv,pmeas)
 end
+
+
+function DiracDelta(trian::Triangulation{Dt}, pvec::Vector{Point{D,T}}) where {Dt,D,T}
+  cell_to_pindices = _cell_to_pindices(pvec,trian)
+  cell_ids = collect(keys(cell_to_pindices))
+  cell_points = collect(values(cell_to_pindices))
+  points = map(i->pvec[cell_points[i]], 1:length(cell_ids))
+  weights_x_cell = Fill.(one(T),length.(cell_points))
+  pquad = map(i -> GenericQuadrature(points[i],weights_x_cell[i]), 1:length(cell_ids))
+  trianv = view(trian,cell_ids)
+  pmeas = Measure(CellQuadrature(pquad,points,weights_x_cell,trianv,PhysicalDomain(),PhysicalDomain()))
+  GenericDiracDelta{0,Dt,NotGridEntity}(trianv,pmeas)
+end
+
+
+function DiracDelta(trian::Triangulation{Dt}, p::Point{D,T}) where {Dt,D,T}    
+  cache = _point_to_cell_cache(KDTreeSearch(),trian)
+  cell = _point_to_cell!(cache, p)
+  trianv = view(trian,[cell])
+  point = [p]
+  weight = [one(T)]
+  pquad = GenericQuadrature(point,weight)
+  pmeas = Measure(CellQuadrature([pquad],[pquad.coordinates],[pquad.weights],trianv,PhysicalDomain(),PhysicalDomain()))
+  GenericDiracDelta{0,Dt,NotGridEntity}(trianv,pmeas)
+end

--- a/test/CellDataTests/DiracDeltasTests.jl
+++ b/test/CellDataTests/DiracDeltasTests.jl
@@ -48,8 +48,14 @@ p = Point(0.2,0.3)
 δ = DiracDelta(model,p)
 @test sum(δ(v)) ≈ v(p)
 
+@show δ = DiracDelta(Ω,p)
+@test sum(δ(v)) ≈ v(p)
+
 pvec = [p,π*p]
 δ = DiracDelta(model,pvec)
+@test sum(δ(v)) ≈ sum(v(pvec))
+
+@show δ = DiracDelta(Ω,pvec)
 @test sum(δ(v)) ≈ sum(v(pvec))
 
 p = Point(0.2,0.3)


### PR DESCRIPTION
DiracDelta definitions were limited to DiscreteModel{D} argument. Introduced constructors for DiracDelta with Triangulation{Dt} argument. 
Added the tests for the same in DiracDeltaTests.jl as well.