### PR TITLE
facilitate differentiating wrt positions x when x is defined as a FEFunction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Added 
+
+- Added functionality to allow automatic differentiation of integrals with respect to evaluation positions xh where xh is a FEFunction. Since PR[#1095](https://github.com/gridap/Gridap.jl/pull/1095)
+
 ## [0.18.11] - 2025-04-01
 
 ### Added

--- a/src/CellData/CellData.jl
+++ b/src/CellData/CellData.jl
@@ -12,6 +12,7 @@ using FillArrays
 using NearestNeighbors
 using StaticArrays
 using DataStructures
+using ForwardDiff
 
 using Gridap.Helpers
 using Gridap.Algebra

--- a/src/CellData/CellFields.jl
+++ b/src/CellData/CellFields.jl
@@ -278,7 +278,7 @@ function _point_to_cell!(cache, x::Point)
   searchmethod, kdtree, vertex_to_cells, cell_to_ctype, ctype_to_polytope, cell_map, table_cache = cache
 
   # Loop over the first m.num_nearest_vertex
-  x_val = ForwardDiff.value.(x.data)
+  x_val = ForwardDiff.value(x)
   for (id,dist) in zip(knn(kdtree, SVector(Tuple(x_val)), searchmethod.num_nearest_vertices, true)...)
 
     # Find all neighbouring cells

--- a/src/CellData/CellFields.jl
+++ b/src/CellData/CellFields.jl
@@ -831,7 +831,7 @@ return_cache(f::CellField,x::Point) = return_cache(Interpolable(f),x)
 function return_cache(a::Interpolable,x::Point)
   f = a.uh
   trian = get_triangulation(f)
-  cache1 = _point_to_cell_cache(a.searchmethod,trian,x)
+  cache1 = _point_to_cell_cache(a.searchmethod,trian)
 
   cell_f = get_array(f)
   cell_f_cache = array_cache(cell_f)
@@ -842,11 +842,11 @@ function return_cache(a::Interpolable,x::Point)
   return cache1,cache2
 end
 
-function _point_to_cell_cache(searchmethod::KDTreeSearch,trian::Triangulation,x)
+function _point_to_cell_cache(searchmethod::KDTreeSearch,trian::Triangulation)
   model = get_active_model(trian)
   topo = get_grid_topology(model)
   vertex_coordinates = Geometry.get_vertex_coordinates(topo)
-  kdtree = KDTree(map(nc -> SVector(NTuple{length(nc),eltype(nc)}(nc)), vertex_coordinates))
+  kdtree = KDTree(map(nc -> SVector(Tuple(nc)), vertex_coordinates))
   D = num_cell_dims(trian)
   vertex_to_cells = get_faces(topo, 0, D)
   cell_to_ctype = get_cell_type(trian)

--- a/src/CellData/CellFields.jl
+++ b/src/CellData/CellFields.jl
@@ -278,7 +278,8 @@ function _point_to_cell!(cache, x::Point)
   searchmethod, kdtree, vertex_to_cells, cell_to_ctype, ctype_to_polytope, cell_map, table_cache = cache
 
   # Loop over the first m.num_nearest_vertex
-  for (id,dist) in zip(knn(kdtree, SVector(Tuple(x)), searchmethod.num_nearest_vertices, true)...)
+  x_val = ForwardDiff.value.(x.data)
+  for (id,dist) in zip(knn(kdtree, SVector(Tuple(x_val)), searchmethod.num_nearest_vertices, true)...)
 
     # Find all neighbouring cells
     cells = getindex!(table_cache,vertex_to_cells,id)
@@ -830,7 +831,7 @@ return_cache(f::CellField,x::Point) = return_cache(Interpolable(f),x)
 function return_cache(a::Interpolable,x::Point)
   f = a.uh
   trian = get_triangulation(f)
-  cache1 = _point_to_cell_cache(a.searchmethod,trian)
+  cache1 = _point_to_cell_cache(a.searchmethod,trian,x)
 
   cell_f = get_array(f)
   cell_f_cache = array_cache(cell_f)
@@ -841,11 +842,11 @@ function return_cache(a::Interpolable,x::Point)
   return cache1,cache2
 end
 
-function _point_to_cell_cache(searchmethod::KDTreeSearch,trian::Triangulation)
+function _point_to_cell_cache(searchmethod::KDTreeSearch,trian::Triangulation,x)
   model = get_active_model(trian)
   topo = get_grid_topology(model)
   vertex_coordinates = Geometry.get_vertex_coordinates(topo)
-  kdtree = KDTree(map(nc -> SVector(Tuple(nc)), vertex_coordinates))
+  kdtree = KDTree(map(nc -> SVector(NTuple{length(nc),eltype(nc)}(nc)), vertex_coordinates))
   D = num_cell_dims(trian)
   vertex_to_cells = get_faces(topo, 0, D)
   cell_to_ctype = get_cell_type(trian)

--- a/src/TensorValues/MultiValueTypes.jl
+++ b/src/TensorValues/MultiValueTypes.jl
@@ -142,3 +142,9 @@ of Paraview. Else, if max(S)>3, they are labeled by integers starting from "1".
 function indep_components_names(::Type{MultiValue{S,T,N,L}}) where {S,T,N,L}
   return ["$i" for i in 1:L]
 end
+
+@inline function ForwardDiff.value(x::MultiValue{S,<:ForwardDiff.Dual}) where S
+  VT = change_eltype(x,ForwardDiff.valtype(eltype(x)))
+  data = map(ForwardDiff.value,x.data)
+  return VT(data)
+end

--- a/src/TensorValues/TensorValues.jl
+++ b/src/TensorValues/TensorValues.jl
@@ -45,6 +45,7 @@ using Gridap.Helpers
 using Gridap.Arrays
 using LinearAlgebra
 using Random
+using ForwardDiff
 
 export MultiValue
 export VectorValue

--- a/test/FESpacesTests/FEAutodiffTests.jl
+++ b/test/FESpacesTests/FEAutodiffTests.jl
@@ -236,4 +236,11 @@ test_array(jac_gridap_h,jac_forwdiff_h,≈)
 # jac_forwdiff_j = ForwardDiff.jacobian(f_,θ)
 # test_array(jac_gridap_j,jac_forwdiff_j,≈)
 
+reffex = ReferenceFE(lagrangian,VectorValue{2,Float64},1)
+Vx = FESpace(Ω,reffex)
+xh = interpolate(VectorValue(0.0,0.0),Vx)
+g(x) = uh(VectorValue(x[1],x[2]))
+f(x) = ∫(g∘(x))dΩ
+gradient(f,xh)
+
 end # module


### PR DESCRIPTION
Minor change to allow for the differentiation of a integral with respect to a FEFunction xh when xh is the locations where a different FEFunction uh should be evaluated i.e. d(\int uh(xh) d\Omega)/d(xh) (see added test).

The change required is to avoid piping duals through the closest nearest neighbor search (a small change in the location of a point will not effect which vertexes are the closest neighbours) but passing dual numbers breaks the search due to non-robustness to duals in NearestNeighbours.jl. 
