### PR TITLE
[Moment based reffes] fixed linear_combination of AbstractVector{<:Dof}

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Raviart on n-cubes `QCurlGradBasis(PT<:Polynomial, Val(D), order)`
 - Added `BernsteinBasisOnSimplex` that implements Bernstein polynomials in barycentric coordinates, since PR[#1104](https://github.com/gridap/Gridap.jl/pull/#1104).
 
+### Fixed
+
+ - Fixed evaluation of `LinearCombinationDofVector` on vector of `<:Field`s (only impacts ModalC0 FEs and future moment based reffes)., since PR[#1104](https://github.com/gridap/Gridap.jl/pull/#1105).
+
 ## [0.18.10] - 2025-03-04
 
 ### Added

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
- - Fixed evaluation of `LinearCombinationDofVector` on vector of `<:Field`s (only impacts ModalC0 FEs and future moment based reffes)., since PR[#1104](https://github.com/gridap/Gridap.jl/pull/#1105).
+ - Fixed evaluation of `LinearCombinationDofVector` on vector of `<:Field`s (only impacts ModalC0 FEs and future moment based reffes)., since PR[#1105](https://github.com/gridap/Gridap.jl/pull/#1105).
 
 ## [0.18.10] - 2025-03-04
 

--- a/src/Fields/FieldArrays.jl
+++ b/src/Fields/FieldArrays.jl
@@ -386,6 +386,7 @@ function return_cache(k::LinearCombinationMap{Colon},v::AbstractMatrix,fx::Abstr
   CachedArray(r)
 end
 
+#  r = fx * v   i.e.  r[p,j] = Σᵢ fx[p,i]*v[i,j]
 function evaluate!(cache,k::LinearCombinationMap{Colon},v::AbstractMatrix,fx::AbstractMatrix)
   @check size(fx,2) == size(v,1)
   setsize!(cache,(size(fx,1),size(v,2)))
@@ -538,7 +539,7 @@ for T in (:(Point),:(AbstractArray{<:Point}))
       cf = return_cache(f,gx)
       return cg, cf
     end
-    
+
     function evaluate!(cache, k::BroadcastOpFieldArray{typeof(∘)},x::$T)
       cg, cf = cache
       f, g = k.args
@@ -733,7 +734,7 @@ for op in (:*,:⋅,:⊙,:⊗)
   end
 end
 
-# Optimisations to 
+# Optimisations to
 # lazy_map(Broadcasting(constant_field),a::AbstractArray{<:AbstractArray{<:Number}})
 
 struct ConstantFieldArray{T,N,A} <: AbstractArray{ConstantField{T},N}

--- a/src/ReferenceFEs/Dofs.jl
+++ b/src/ReferenceFEs/Dofs.jl
@@ -23,6 +23,13 @@ struct LinearCombinationDofVector{T,V,F} <: AbstractVector{T}
     values::AbstractMatrix{<:Number},
     dofs::AbstractVector{<:Dof}
   )
+    @check size(values,1) == length(dofs) """\n
+    Incompatible sizes for performing the linear combination
+
+        linear_combination(values,dofs) = transpose(values)*dofs
+
+    size(values,1) != length(dofs)
+    """
     T = eltype(dofs)
     V = typeof(values)
     F = typeof(dofs)
@@ -42,7 +49,7 @@ function return_cache(b::LinearCombinationDofVector,field)
   k = Fields.LinearCombinationMap(:)
   cf = return_cache(b.dofs,field)
   fx = evaluate!(cf,b.dofs,field)
-  ck = return_cache(k,b.values,fx)
+  ck = return_cache(k,fx,transpose(b.values))
   return cf, ck
 end
 
@@ -50,7 +57,7 @@ function evaluate!(cache,b::LinearCombinationDofVector,field)
   cf, ck = cache
   k = Fields.LinearCombinationMap(:)
   fx = evaluate!(cf,b.dofs,field)
-  return evaluate!(ck,k,b.values,fx)
+  return evaluate!(ck,k,fx,transpose(b.values))
 end
 
 """

--- a/src/ReferenceFEs/ReferenceFEInterfaces.jl
+++ b/src/ReferenceFEs/ReferenceFEInterfaces.jl
@@ -488,7 +488,9 @@ struct GenericRefFE{T,D} <: ReferenceFE{D}
       conformity,
       metadata,
       face_dofs,
-      linear_combination(Eye{Int}(ndofs),shapefuns)) # Trick to be able to eval dofs af shapefuns in physical space
+      # Trick to be able to eval dofs af shapefuns in physical space
+      # cf /test/FESpacesTests/PhysicalFESpacesTests.jl
+      linear_combination(Eye{Int}(ndofs),shapefuns))
   end
 end
 

--- a/test/FESpacesTests/PhysicalFESpacesTests.jl
+++ b/test/FESpacesTests/PhysicalFESpacesTests.jl
@@ -49,4 +49,15 @@ uh = interpolate(u,V)
 e = u - uh
 @test sqrt(sum(∫(e*e)*dΩ)) < 10e-8
 
+# Checking that dofs and shapfuns from a reffe with a dof prebasis (and shapefun=prebasis) can be evaluated in physical space
+
+order = 3
+reffe = ReferenceFE(modalC0,Float64,order)
+V = FESpace(model,reffe,conformity=:H1)
+
+shfns_g = get_fe_basis(V)
+phys_shfns_g = change_domain(shfns_g,PhysicalDomain())
+dofs_f = get_fe_dof_basis(V)
+@test_nowarn dofs_f(phys_shfns_g)
+
 end #module

--- a/test/ReferenceFEsTests/DofsTests.jl
+++ b/test/ReferenceFEsTests/DofsTests.jl
@@ -1,3 +1,41 @@
 module DofsTests
 
+using Test
+using Gridap
+using Gridap.ReferenceFEs
+using Gridap.Fields
+using FillArrays
+
+T = Float64
+
+reffe0 = ReferenceFE(SEGMENT, Lagrangian(), Float64, 2)
+reffe1 = ReferenceFE(SEGMENT, Lagrangian(), Float64, 3)
+
+dofs  = get_dof_basis(reffe0)                  # length 3
+@test dofs    isa AbstractVector{<:Dof}
+
+dofs_lc = linear_combination(Eye(3,6), dofs)   # length 6
+@test dofs_lc isa AbstractVector{<:Dof}
+@test length(dofs_lc) == 6
+
+basis = get_prebasis(reffe1)                   # length 4
+@test basis    isa AbstractVector{<:Field}
+basis_lc = linear_combination(Eye(4,5), basis) # length 5
+
+@test basis_lc isa AbstractVector{<:Field}
+@test length(basis_lc) == 5
+
+M34 = evaluate(dofs,    basis   )
+M35 = evaluate(dofs,    basis_lc)
+M64 = evaluate(dofs_lc, basis   )
+M65 = evaluate(dofs_lc, basis_lc)
+
+@test size(M34) == (3, 4)
+@test size(M35) == (3, 5)
+@test size(M64) == (6, 4)
+@test size(M65) == (6, 5)
+@test M35[1:3,1:4] == M34
+@test M64[1:3,1:4] == M34
+@test M65[1:3,1:4] == M34
+
 end # module

--- a/test/ReferenceFEsTests/ReferenceFEInterfacesTests.jl
+++ b/test/ReferenceFEsTests/ReferenceFEInterfacesTests.jl
@@ -48,4 +48,21 @@ shapefuns = get_shapefuns(reffe)
 
 @test get_own_dofs_permutations(reffe) == face_own_dofs_permutations[end]
 
+# dof prebasis inversion from given shape functions
+dofprebasis = dofs
+shapefuns = prebasis # just to get nontrivial dofs change of basis matrix
+
+reffe = GenericRefFE{typeof(conf)}(
+  ndofs, polytope, dofprebasis, conf, metadata, face_dofs, shapefuns)
+
+test_reference_fe(reffe)
+
+@test get_face_own_dofs(reffe,L2Conformity()) == [[], [], [], [], [], [], [], [], [1, 2, 3, 4]]
+@test get_face_own_dofs_permutations(reffe,L2Conformity()) == [[[]], [[]], [[]], [[]], [[]], [[]], [[]], [[]], [[1, 2, 3, 4]]]
+@test get_own_dofs_permutations(reffe) == face_own_dofs_permutations[end]
+
+dofs = get_dof_basis(reffe)
+
+@test evaluate(dofs,shapefuns) == [1.0 0.0 0.0 0.0; 0.0 1.0 0.0 0.0; 0.0 0.0 1.0 0.0; 0.0 0.0 0.0 1.0]
+
 end # module


### PR DESCRIPTION
Cf [test/ReferenceFEsTests/DofsTests.jl](https://github.com/gridap/Gridap.jl/compare/moment-based-reffes...Antoinemarteau:Gridap.jl:moment-based-reffes?expand=1#diff-005e4fb1bbf8e2094d46de29a72a2a29b9a0858e0c37c747cb52a7bbac35c8b7), the last 5 tests were broken, this also means that `ReferenceFEs.compute_dofs` would previously not return the dual dof basis of the given shape functions.
This only previously impacted reffes were the ModalC0 ones, I don't know why the tests passed before (and still pass now).

A also added a test for this weird trick [ src/ReferenceFEs/ReferenceFEInterfaces.jl](https://github.com/gridap/Gridap.jl/compare/moment-based-reffes...Antoinemarteau:Gridap.jl:moment-based-reffes?expand=1#diff-c9884951823067f41aadabf4fc0f18dd5631764d903952a7337940c73f69e58a) so that the next person that tries to remove it encounters a broken test...