### PR TITLE
Added tolerance to Interpolables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- The `tol` kwarg for `Interpolable` was unused. It is now used for the point-to-cell search, which was breaking for very small cell sizes. Since PR[#1106](https://github.com/gridap/Gridap.jl/pull/1106).
+
 ## [0.18.12] - 2025-04-19
 
 ### Added


### PR DESCRIPTION
The `tol` kwarg for `Interpolable` was unused. It is now used for the point-to-cell search, which was breaking for very small cell sizes. 
