### PR TITLE
Fix get_bounding_box(::Polytope)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix bug for issue [#927](https://github.com/gridap/Gridap.jl/issues/927), where Nedelec FE would not work on faces (Dc < Dp). Since PR[#1094](https://github.com/gridap/Gridap.jl/pull/1094).
 - Added support to evaluate polynomial bases on dualized points. Since PR[#1100](https://github.com/gridap/Gridap.jl/pull/1100).
-- Fix bug in `get_bounding_box`. Since PR[#1107](https://github.com/gridap/Gridap.jl/pull/1107).
+- Fix bug in `get_bounding_box`. Since PR[#1108](https://github.com/gridap/Gridap.jl/pull/1108).
 
 ## [0.18.11] - 2025-04-01
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix bug for issue [#927](https://github.com/gridap/Gridap.jl/issues/927), where Nedelec FE would not work on faces (Dc < Dp). Since PR[#1094](https://github.com/gridap/Gridap.jl/pull/1094).
 - Added support to evaluate polynomial bases on dualized points. Since PR[#1100](https://github.com/gridap/Gridap.jl/pull/1100).
+- Fix bug in `get_bounding_box`. Since PR[#1107](https://github.com/gridap/Gridap.jl/pull/1107).
 
 ## [0.18.11] - 2025-04-01
 

--- a/src/ReferenceFEs/Polytopes.jl
+++ b/src/ReferenceFEs/Polytopes.jl
@@ -660,18 +660,14 @@ end
     get_bounding_box(p::Polytope{D}) where D
 """
 function get_bounding_box(p::Polytope{D}) where D
-  vertex_to_coords = get_vertex_coordinates(p)
-  P = eltype(vertex_to_coords)
-  T = eltype(P)
-  pmin = Point(tfill(T(Inf),Val{D}()))
-  pmax = Point(tfill(T(-Inf),Val{D}()))
-  for coord in vertex_to_coords
-    if coord < pmin
-      pmin = coord
-    end
-    if coord > pmax
-      pmax = coord
-    end
+  vertices_coords = get_vertex_coordinates(p)
+  P = eltype(vertices_coords)
+  @check length(P) == D
+  pmin = P( tfill( Inf,Val(D)) )
+  pmax = P( tfill(-Inf,Val(D)) )
+  for coord in vertices_coords
+      pmin = min.(coord, pmin)
+      pmax = max.(coord, pmax)
   end
   (pmin,pmax)
 end

--- a/test/ReferenceFEsTests/PolytopesTests.jl
+++ b/test/ReferenceFEsTests/PolytopesTests.jl
@@ -129,8 +129,11 @@ test_polytope(q)
 d = 1
 @test get_dimrange(q,d) == get_dimranges(q)[d+1]
 
-pmin, pmax = get_bounding_box(HEX)
-@test pmin == Point(0,0,0)
-@test pmax == Point(1,1,1)
+for p in (VERTEX, SEGMENT, TRI, QUAD, TET, HEX, PYRAMID, WEDGE)
+  pmin, pmax = get_bounding_box(p)
+  D = num_dims(p)
+  @test pmin == Point(ntuple(_->0., D))
+  @test pmax == Point(ntuple(_->1., D))
+end
 
 end # module


### PR DESCRIPTION
The algorithm was wrong and only worked on e.g. n-cubes reference polytope.