### PR TITLE
Scaled contravariant piola map for Div-conforming elements

### DIFF
--- a/src/FESpaces/ConformingFESpaces.jl
+++ b/src/FESpaces/ConformingFESpaces.jl
@@ -95,14 +95,15 @@ function CellFE(
   model::DiscreteModel,
   cell_reffe::AbstractArray{<:ReferenceFE},
   conformity::Conformity,
-  args...
+  args...;
+  kwargs...
  )
   cell_conformity = CellConformity(cell_reffe,conformity)
   ctype_reffe, cell_ctype = compress_cell_data(cell_reffe)
   ctype_num_dofs = map(num_dofs,ctype_reffe)
   ctype_ldof_comp = map(reffe->get_dof_to_comp(reffe),ctype_reffe)
-  cell_shapefuns = get_cell_shapefuns(model,cell_reffe,conformity,args...)
-  cell_dof_basis = get_cell_dof_basis(model,cell_reffe,conformity,args...)
+  cell_shapefuns = get_cell_shapefuns(model,cell_reffe,conformity,args...;kwargs...)
+  cell_dof_basis = get_cell_dof_basis(model,cell_reffe,conformity,args...;kwargs...)
   cell_shapefuns_domain = ReferenceDomain()
   cell_dof_basis_domain = cell_shapefuns_domain
   max_order = maximum(map(get_order,ctype_reffe))
@@ -122,13 +123,17 @@ end
 
 function get_cell_dof_basis(model::DiscreteModel,
                             cell_reffe::AbstractArray{<:ReferenceFE},
-                            ::Conformity)
+                            ::Conformity,
+                            args...;
+                            kwargs...)
   lazy_map(get_dof_basis,cell_reffe)
 end
 
 function get_cell_shapefuns(model::DiscreteModel,
                             cell_reffe::AbstractArray{<:ReferenceFE},
-                            ::Conformity)
+                            ::Conformity, 
+                            args...;
+                            kwargs...)
   lazy_map(get_shapefuns,cell_reffe)
 end
 

--- a/src/FESpaces/CurlConformingFESpaces.jl
+++ b/src/FESpaces/CurlConformingFESpaces.jl
@@ -2,7 +2,9 @@
 function get_cell_dof_basis(
   model::DiscreteModel,
   cell_reffe::AbstractArray{<:GenericRefFE{Nedelec}},
-  ::CurlConformity)
+  ::CurlConformity,
+  args...;
+  kwargs...)
   cell_map  = get_cell_map(Triangulation(model))
   phi       = cell_map[1]
   reffe     = cell_reffe[1]
@@ -50,7 +52,9 @@ end
 function get_cell_shapefuns(
   model::DiscreteModel,
   cell_reffe::AbstractArray{<:GenericRefFE{Nedelec}},
-  ::CurlConformity)
+  ::CurlConformity, 
+  args...;
+  kwargs...)
 
   cell_reffe_shapefuns = lazy_map(get_shapefuns,cell_reffe)
   cell_map = get_cell_map(Triangulation(model))

--- a/src/FESpaces/DivConformingFESpaces.jl
+++ b/src/FESpaces/DivConformingFESpaces.jl
@@ -29,7 +29,8 @@ struct TransformRTDofBasis{Dc,Dp} <: Map end ;
 function get_cell_dof_basis(model::DiscreteModel,
                             cell_reffe::AbstractArray{<:GenericRefFE{<:DivConforming}},
                             ::DivConformity,
-                            sign_flip=get_sign_flip(model, cell_reffe))
+                            map_type=nothing)
+    sign_flip = get_sign_flip(model, cell_reffe)
     cell_map  = get_cell_map(Triangulation(model))
     phi       = cell_map[1]
     Jt        = lazy_map(Broadcasting(∇),cell_map)
@@ -48,9 +49,16 @@ end
 function get_cell_shapefuns(model::DiscreteModel,
                             cell_reffe::AbstractArray{<:GenericRefFE{<:DivConforming}},
                             ::DivConformity,
-                            sign_flip=get_sign_flip(model, cell_reffe))
+                            map_type=nothing)
+    sign_flip=get_sign_flip(model, cell_reffe)
     cell_reffe_shapefuns=lazy_map(get_shapefuns,cell_reffe)
-    k=ContraVariantPiolaMap()
+
+    if map_type == nothing
+      k=ContraVariantPiolaMap()
+    else 
+      k=map_type
+    end
+    
     lazy_map(k,
              cell_reffe_shapefuns,
              get_cell_map(Triangulation(model)),

--- a/src/FESpaces/DivConformingFESpaces.jl
+++ b/src/FESpaces/DivConformingFESpaces.jl
@@ -29,8 +29,9 @@ struct TransformRTDofBasis{Dc,Dp} <: Map end ;
 function get_cell_dof_basis(model::DiscreteModel,
                             cell_reffe::AbstractArray{<:GenericRefFE{<:DivConforming}},
                             ::DivConformity,
-                            map_type=nothing)
-    sign_flip = get_sign_flip(model, cell_reffe)
+                            args...; 
+                            sign_flip=get_sign_flip(model, cell_reffe),
+                            kwargs...)
     cell_map  = get_cell_map(Triangulation(model))
     phi       = cell_map[1]
     Jt        = lazy_map(Broadcasting(∇),cell_map)
@@ -49,17 +50,13 @@ end
 function get_cell_shapefuns(model::DiscreteModel,
                             cell_reffe::AbstractArray{<:GenericRefFE{<:DivConforming}},
                             ::DivConformity,
-                            map_type=nothing)
-    sign_flip=get_sign_flip(model, cell_reffe)
+                            args...; 
+                            sign_flip=get_sign_flip(model, cell_reffe),
+                            contra_variant_piola_map_type=ContraVariantPiolaMap(),
+                            kwargs...)
     cell_reffe_shapefuns=lazy_map(get_shapefuns,cell_reffe)
-
-    if map_type == nothing
-      k=ContraVariantPiolaMap()
-    else 
-      k=map_type
-    end
     
-    lazy_map(k,
+    lazy_map(contra_variant_piola_map_type,
              cell_reffe_shapefuns,
              get_cell_map(Triangulation(model)),
              lazy_map(Broadcasting(constant_field), sign_flip))

--- a/src/FESpaces/FESpaceFactories.jl
+++ b/src/FESpaces/FESpaceFactories.jl
@@ -71,7 +71,8 @@ function FESpace(
   dirichlet_tags=Int[],
   dirichlet_masks=nothing,
   constraint=nothing,
-  vector_type=nothing)
+  vector_type=nothing,
+  map_type=nothing)
 
   conf = Conformity(testitem(cell_reffe),conformity)
 
@@ -89,8 +90,13 @@ function FESpace(
       trian)
     return V
   end
+  
+  if map_type == nothing
+    cell_fe = CellFE(model,cell_reffe,conf)
+  else
+    cell_fe = CellFE(model,cell_reffe,conf,map_type)
+  end
 
-  cell_fe = CellFE(model,cell_reffe,conf)
   _vector_type = _get_vector_type(vector_type,cell_fe,trian)
   if conformity in (L2Conformity(),:L2) && dirichlet_tags == Int[]
     F = _DiscontinuousFESpace(_vector_type,trian,cell_fe)

--- a/src/FESpaces/FESpaceFactories.jl
+++ b/src/FESpaces/FESpaceFactories.jl
@@ -72,7 +72,7 @@ function FESpace(
   dirichlet_masks=nothing,
   constraint=nothing,
   vector_type=nothing,
-  map_type=nothing)
+  contra_variant_piola_map_type::ContraVariantPiolaMapType=ContraVariantPiolaMap())
 
   conf = Conformity(testitem(cell_reffe),conformity)
 
@@ -91,11 +91,7 @@ function FESpace(
     return V
   end
   
-  if map_type == nothing
-    cell_fe = CellFE(model,cell_reffe,conf)
-  else
-    cell_fe = CellFE(model,cell_reffe,conf,map_type)
-  end
+  cell_fe = CellFE(model,cell_reffe,conf;contra_variant_piola_map_type=contra_variant_piola_map_type)
 
   _vector_type = _get_vector_type(vector_type,cell_fe,trian)
   if conformity in (L2Conformity(),:L2) && dirichlet_tags == Int[]

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -28,7 +28,7 @@ import LinearAlgebra: det, inv, transpose, tr, cross
 import LinearAlgebra: ⋅, dot
 
 import Base: +, -, *, /
-import Gridap.TensorValues: ⊗, ⊙, symmetric_part, outer, meas
+import Gridap.TensorValues: ⊗, ⊙, symmetric_part, outer, meas, scaled_meas
 
 import Gridap.Arrays: IndexStyle
 import Gridap.Arrays: return_cache

--- a/src/Fields/FieldsInterfaces.jl
+++ b/src/Fields/FieldsInterfaces.jl
@@ -363,7 +363,7 @@ evaluate!(cache,op::Broadcasting{<:Operation},x::Field...) = OperationField(op.f
 
 # Define some well known operations
 
-for op in (:+,:-,:*,:/,:⋅,:⊙,:⊗,:inv,:det,:meas,:pinvJt,:tr,:grad2curl,:symmetric_part,:transpose)
+for op in (:+,:-,:*,:/,:⋅,:⊙,:⊗,:inv,:det,:meas,:scaled_meas,:pinvJt,:tr,:grad2curl,:symmetric_part,:transpose)
   @eval ($op)(a::Field...) = Operation($op)(a...)
 end
 

--- a/src/ReferenceFEs/RaviartThomasRefFEs.jl
+++ b/src/ReferenceFEs/RaviartThomasRefFEs.jl
@@ -374,8 +374,9 @@ function _eval_moment_dof_basis!(dofs,vals::AbstractMatrix,b)
   end
 end
 
-struct ContraVariantPiolaMap <: Map end
-struct ScaledContraVariantPiolaMap <: Map end
+abstract type ContraVariantPiolaMapType <: Map end
+struct ContraVariantPiolaMap <: ContraVariantPiolaMapType end
+struct ScaledContraVariantPiolaMap <: ContraVariantPiolaMapType end
 
 function evaluate!(
   cache,

--- a/src/ReferenceFEs/ReferenceFEs.jl
+++ b/src/ReferenceFEs/ReferenceFEs.jl
@@ -96,6 +96,7 @@ export HEX_AXIS
 export TET_AXIS
 export INVALID_PERM
 
+export ContraVariantPiolaMapType
 export ContraVariantPiolaMap
 export ScaledContraVariantPiolaMap
 

--- a/src/ReferenceFEs/ReferenceFEs.jl
+++ b/src/ReferenceFEs/ReferenceFEs.jl
@@ -97,6 +97,7 @@ export TET_AXIS
 export INVALID_PERM
 
 export ContraVariantPiolaMap
+export ScaledContraVariantPiolaMap
 
 export Dof
 export get_nodes

--- a/src/TensorValues/Operations.jl
+++ b/src/TensorValues/Operations.jl
@@ -789,6 +789,20 @@ function meas(Jt::MultiValue{Tuple{D1,D2}}) where {D1,D2}
 end
 
 """
+    scaled_meas(J::MultiValue{Tuple{D1,D2}})
+
+Returns a rescaled version of the `D1`-dimensional volume of the parallelepiped
+formed by the rows of `J`, that is `sqrt(det(J⋅Jᵀ))^(1/D1)`, or `abs(det(J))^(1/D1)` if `D1`=`D2`.
+This is used to compute the scaled contribution of the Jacobian matrix `J` of a changes of variables in integrals, e.g. used in the ScaledContraVariantPiolaMap.
+"""
+scaled_meas(a::MultiValue{Tuple{D,D}}) where D = abs(det(a))^(1/D)
+
+function scaled_meas(Jt::MultiValue{Tuple{D1,D2}}) where {D1,D2}
+  J = transpose(Jt)
+  sqrt(det(Jt⋅J))^(1/D1)
+end
+
+"""
     norm(u::MultiValue{Tuple{D}})
     norm(u::MultiValue{Tuple{D1,D2}})
 

--- a/src/TensorValues/TensorValues.jl
+++ b/src/TensorValues/TensorValues.jl
@@ -57,7 +57,7 @@ export QTensorValue
 export SymFourthOrderTensorValue
 export ThirdOrderTensorValue
 
-export inner, outer, meas
+export inner, outer, meas, scaled_meas
 export mutable
 export Mutable
 export symmetric_part


### PR DESCRIPTION
This PR allows the user to specify whether a HDiv-conforming element (e.g. Raviart-Thomas or BDM) should be used with the (default) contravariant Piola map or a rescaled version through the use of an extra (optional) argument in `FESpace` when constructing an HDiv-conforming finite element space, e.g. `FESpace(model, reffe_RT, conformity=:HDiv, contra_variant_piola_map_type=ScaledContraVariantPiolaMap())`. The scaled contravariant Piola map is defined as the standard contravariant Piola map for which the determinant of the Jacobi matrix is rescaled using `^{1/D}` (with `D` the `D1`-dimensional volume of the parallelepiped formed by the rows of `J`). The use of this scaled contravariant Piola map can result in better conditioning of certain (mixed) problems, such as the Darcy equation.

For this to work,
- the interface of `CellFE` has been updated to not only pass along `args` but also `kwargs` to `get_cell_shapefuns` and `get_cell_dof_basis`, so that the user can (optionally) specify the `contra_variant_piola_map_type` in `FESpace`;
- the `scaled_meas` operation has been introduced to define the scaled version of the contravariant Piola map;
- the `lazy_map`'s and `evaluate!`'s are changed in `RaviartThomasRefFEs.jl`so that either the default operation `ContraVariantPiolaMap()` or the selected (`ContraVariantPiolaMap()` or `ScaledContraVariantPiolaMap()`) is performed.