### PR TITLE
Enable non-surjective n2o maps for AdaptivityGlue

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Update `norm` function to be compatible with complex vectors and tensors. Since PR[#1118](https://github.com/gridap/Gridap.jl/pull/1118).
-- `AdaptivityGlue` can now deal with non-surjective n2o maps. Since PR[XXX](XXX).
+- `AdaptivityGlue` can now deal with non-surjective n2o maps. Since PR[#1126](https://github.com/gridap/Gridap.jl/pull/1126).
 
 
 ## [0.19.1] - 2025-06-11

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Update `norm` function to be compatible with complex vectors and tensors. Since PR[#1118](https://github.com/gridap/Gridap.jl/pull/1118).
+- `AdaptivityGlue` can now deal with non-surjective n2o maps. Since PR[XXX](XXX).
+
 
 ## [0.19.1] - 2025-06-11
 

--- a/src/Adaptivity/AdaptivityGlues.jl
+++ b/src/Adaptivity/AdaptivityGlues.jl
@@ -51,7 +51,7 @@ struct AdaptivityGlue{GT,Dc,A,B,C,D,E} <: GridapType
     end
     Dc = length(n2o_faces_map)-1
     is_refined    = select_refined_cells(n2o_faces_map[Dc+1])
-    o2n_faces_map = Arrays.inverse_table(n2o_faces_map[Dc+1])
+    o2n_faces_map = Arrays.inverse_table(n2o_faces_map[Dc+1], length(refinement_rules))
     A = typeof(n2o_faces_map)
     B = typeof(n2o_cell_to_child_id)
     C = typeof(refinement_rules)


### PR DESCRIPTION
Fix AdaptivityGlue such that it is now able to work with non-surjective n2o maps as per-required by GridapP4est whenever we have more than one ghost layer