### PR TITLE
Fixing the sum of basis functions

### DIFF
--- a/src/Fields/FieldArrayBlocks.jl
+++ b/src/Fields/FieldArrayBlocks.jl
@@ -633,18 +633,17 @@ function evaluate!(cache,k::BroadcastingFieldOpMap,a::Union{ArrayBlock,AbstractA
 end
 
 for op in (:+,:-,:*)
-  local type = :(Broadcasting{<:Union{Operation{typeof($op)}, typeof($op)}})
   @eval begin
 
-    function return_value(k::$type,f::ArrayBlock,g::ArrayBlock)
+    function return_value(k::Broadcasting{typeof($op)},f::ArrayBlock,g::ArrayBlock)
       return_value(BroadcastingFieldOpMap($op),f,g)
     end
 
-    function return_cache(k::$type,f::ArrayBlock,g::ArrayBlock)
+    function return_cache(k::Broadcasting{typeof($op)},f::ArrayBlock,g::ArrayBlock)
       return_cache(BroadcastingFieldOpMap($op),f,g)
     end
 
-    function evaluate!(cache,k::$type,f::ArrayBlock,g::ArrayBlock)
+    function evaluate!(cache,k::Broadcasting{typeof($op)},f::ArrayBlock,g::ArrayBlock)
       evaluate!(cache,BroadcastingFieldOpMap($op),f,g)
     end
 

--- a/src/Fields/FieldArrays.jl
+++ b/src/Fields/FieldArrays.jl
@@ -560,23 +560,23 @@ return_value(a::BroadcastingFieldOpMap,args::AbstractArray...) = return_value(Br
 return_cache(a::BroadcastingFieldOpMap,args::AbstractArray...) = return_cache(Broadcasting(a.op),args...)
 evaluate!(cache,a::BroadcastingFieldOpMap,args::AbstractArray...) = evaluate!(cache,Broadcasting(a.op),args...)
 
-# The following code is implemented to store `Transpose`
-# only for `Field`, which is needed when using `CachedArray`.
-function testitem(
-  a::LazyArray{A,<:ArrayBlock{<:Transpose{<:Field}}}) where {A} 
-  if length(a) > 0 && typeof(first(a)) == eltype(a)
-    first(a)
-  else
-    testvalue(eltype(a))
-  end
-end
-
-function return_cache(k::BroadcastingFieldOpMap,a::AbstractArray{<:Field},b::AbstractArray{<:Field})
-  @check size(a) == size(b) || (length(a)==0 && length(b)==0) 
-  O = typeof(k.op)
-  F = Tuple{eltype(a),eltype(b)}
-  CachedArray(OperationField{O,F},ndims(a))
-end
+# # The following code is implemented to store `Transpose`
+# # only for `Field`, which is needed when using `CachedArray`.
+# function testitem(
+#   a::LazyArray{A,<:ArrayBlock{<:Transpose{<:Field}}}) where {A} 
+#   if length(a) > 0 && typeof(first(a)) == eltype(a)
+#     first(a)
+#   else
+#     testvalue(eltype(a))
+#   end
+# end
+# 
+# function return_cache(k::BroadcastingFieldOpMap,a::AbstractArray{<:Field},b::AbstractArray{<:Field})
+#   @check size(a) == size(b) || (length(a)==0 && length(b)==0) 
+#   O = typeof(k.op)
+#   F = Tuple{eltype(a),eltype(b)}
+#   CachedArray(OperationField{O,F},ndims(a))
+# end
 
 # Follow optimizations are very important to achieve performance
 


### PR DESCRIPTION
In this PR I am reverting some of the fixes in #1130 and implementing them properly. This also closes #1131 , which was caused by the fixes. 

The issue is that `BroadcastingFieldOpMap` is reserved for **results** of evaluating fields, and therefore expects the arrays to be full of numbers. It should not be used for fields themselves. 

- [x] Revert changes, going back to the previous version of the code. 
- [ ] Implement the sum of basis functions properly so that the new tests pass again. 