### PR TITLE
[Moment based reffes] Fix broken links, BubbleRefFE improvements

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -41,7 +41,7 @@ makedocs(
   modules = [Gridap],
   pages = pages,
   doctest = false,
-  warnonly = [:cross_references,:missing_docs],
+  warnonly = [:missing_docs], # ,:cross_references
   checkdocs = :exports,
 )
 

--- a/docs/src/ReferenceFEs.md
+++ b/docs/src/ReferenceFEs.md
@@ -42,6 +42,7 @@ The following table summarizes the elements implemented in Gridap (legend below)
 |                                                                                                                                                                                                |
 | [Crouzeix-Raviart](https://defelement.org/elements/crouzeix-raviart.html)               |[`couzeix_raviart`](@ref CrouzeixRaviartRefFE)|            |  `TRI`      | ``{r=1, r}``   | `:L2`     |
 | [discontinuous Lagrangian](https://defelement.org/elements/discontinuous-lagrange.html) | [`lagrangian`](@ref LagrangianRefFE)         | ...Λᴰ      | as above    | ``{r≥0, r}``   | `:L2`     |
+| [MINI bubble](@ref "Bubble reference FE")                                               | [`bubble`](@ref BubbleRefFE)                 |            |△,``\square``| ``{r=1, 2}``   | `:L2`     |
 | Serendipity, Bezier, ModalC0                                                            | as above                                     |            |             | ``{r≥0, r}``   | `:L2`     |
 |                                                                                                                                                                                                |
 | [Arnold-Winther](https://defelement.org/elements/arnold-winther.html)                   | `TODO`  `arnoldwinther`                      |        | `TRI`       | ``{r=2, 4}``   | `:Hdiv`   |
@@ -78,6 +79,12 @@ component of the tensor.
 
 The `modalC0` element has the particularity that it's polytope and thus the
 shape function support can be adapted to the physical element.
+
+###### Bubble reference FE
+
+The [`BubbleRefFE`](@ref) currently implements bubble space for MINI element,
+but the bubble can be fine-tuned. The MINI element on `TRI`angle is documented
+[here](https://defelement.org/elements/mini.html).
 
 ```@docs
 ReferenceFEs
@@ -142,7 +149,7 @@ Pages   = ["ReferenceFEInterfaces.jl","Dofs.jl","LinearCombinationDofVectors.jl"
 ```@autodocs
 Modules = [ReferenceFEs,]
 Order   = [:type, :constant, :macro, :function]
-Pages   = ["LagrangianRefFEs.jl","LagrangianDofBases.jl","SerendipityRefFEs.jl","BezierRefFEs.jl","ModalC0RefFEs.jl"]
+Pages   = ["LagrangianRefFEs.jl","LagrangianDofBases.jl","SerendipityRefFEs.jl","BezierRefFEs.jl","ModalC0RefFEs.jl","BubbleRefFEs.jl"]
 ```
 
 ### Moment-Based ReferenceFEs

--- a/src/CellData/Interpolation.jl
+++ b/src/CellData/Interpolation.jl
@@ -194,6 +194,9 @@ function distance(polytope::ExtrusionPolytope, inv_cmap::Field, x::Point)
   end
 end
 
+"""
+    make_inverse_table(i2j::AbstractVector{<:Integer}, nj::Int)
+"""
 function make_inverse_table(i2j::AbstractVector{<:Integer},nj::Int)
   ni = length(i2j)
   @assert nj≥0

--- a/src/CellData/Interpolation.jl
+++ b/src/CellData/Interpolation.jl
@@ -1,5 +1,5 @@
 
-# This file implements code to evaluate CellFields on arbitrary points, based 
+# This file implements code to evaluate CellFields on arbitrary points, based
 # on tree searches.
 
 """

--- a/src/Polynomials/PolynomialInterfaces.jl
+++ b/src/Polynomials/PolynomialInterfaces.jl
@@ -67,6 +67,8 @@ abstract type PolynomialBasis{D,V,PT<:Polynomial} <: AbstractVector{PT}  end
 Return the maximum polynomial order in a dimension, or `0` in 0D.
 """
 @inline get_order(::PolynomialBasis) = @abstractmethod
+get_order(f::Fields.LinearCombinationFieldVector) = get_order(f.fields)
+get_order(f::AbstractVector{<:ConstantField}) = 0
 
 
 ###########

--- a/src/ReferenceFEs/BubbleRefFEs.jl
+++ b/src/ReferenceFEs/BubbleRefFEs.jl
@@ -2,85 +2,85 @@ struct Bubble <: ReferenceFEName end
 const bubble = Bubble()
 
 function BubbleRefFE(::Type{T}, p::Polytope{D}; type = :mini, coeffs = nothing, terms = nothing) where {T, D}
-	@notimplementedif D < 1 "Bubble reference finite elements are only defined for D >= 1."
+  @notimplementedif D < 1 "Bubble reference finite elements are only defined for D >= 1."
 
-	if isnothing(coeffs) && isnothing(terms)
-		if type == :mini
-			terms, coeffs = _mini_bubble_terms_and_coeffs(T, p)
-		else
-			@notimplemented "Only :mini is supported now; however, you may also specify `terms` and `coeffs` manually."
-		end
-	elseif isnothing(terms) || isnothing(coeffs)
-		@error "You must specify both `terms` and `coeffs` or neither."
-	end
+  if isnothing(coeffs) && isnothing(terms)
+    if type == :mini
+      terms, coeffs = _mini_bubble_terms_and_coeffs(T, p)
+    else
+      @notimplemented "Only :mini is supported now; however, you may also specify `terms` and `coeffs` manually."
+    end
+  elseif isnothing(terms) || isnothing(coeffs)
+    @error "You must specify both `terms` and `coeffs` or neither."
+  end
 
-	orders = Tuple(maximum(terms) - oneunit(eltype(terms)))
-	prebasis = linear_combination(coeffs, MonomialBasis(Val(D), T, orders, terms))
-	x0 = mean(get_vertex_coordinates(p))
-	dofs = LagrangianDofBasis(T, [x0])
-	ndofs = length(dofs)
-	face_dofs = [Int[] for _ in 1:num_faces(p)]
-	face_dofs[end] = 1:ndofs
-	shapefuncs = compute_shapefuns(dofs, prebasis)
-	conformity = L2Conformity()
-	metadata = nothing
+  orders = Tuple(maximum(terms) - oneunit(eltype(terms)))
+  prebasis = linear_combination(coeffs, MonomialBasis(Val(D), T, orders, terms))
+  x0 = mean(get_vertex_coordinates(p))
+  dofs = LagrangianDofBasis(T, [x0])
+  ndofs = length(dofs)
+  face_dofs = [Int[] for _ in 1:num_faces(p)]
+  face_dofs[end] = 1:ndofs
+  shapefuncs = compute_shapefuns(dofs, prebasis)
+  conformity = L2Conformity()
+  metadata = nothing
 
-	return GenericRefFE{Bubble}(
-		ndofs,
-		p,
-		prebasis,
-		dofs,
-		conformity,
-		metadata,
-		face_dofs,
-		shapefuncs,
-	)
+  return GenericRefFE{Bubble}(
+    ndofs,
+    p,
+    prebasis,
+    dofs,
+    conformity,
+    metadata,
+    face_dofs,
+    shapefuncs,
+  )
 end
 
 get_order(reffe::GenericRefFE{Bubble}) = num_vertices(reffe.polytope)
 
 function ReferenceFE(p::Polytope, ::Bubble, ::Type{T}; kwargs...) where {T}
-	return BubbleRefFE(T, p; kwargs...)
+  return BubbleRefFE(T, p; kwargs...)
 end
 
 function _mini_bubble_terms_and_coeffs(::Type{T}, p::Polytope{D}) where {T, D}
-	et = eltype(T)
-	if is_simplex(p)
-		# x_1x_2...x_D(1-x_1-x_2-...-x_D)
-		terms = Vector{CartesianIndex{D}}(undef, D+1)
-		@inbounds for j ∈ 1:D
-			# x_1x_2...x_{j-1}(x_j^2)x_{j+1}...x_D
-			terms[j] = CartesianIndex(ntuple(i->i==j ? 3 : 2, Val{D}()))
-		end
-		# x_1x_2...x_D
-		terms[D+1] = CartesianIndex(tfill(2, Val{D}()))
-		coeff = fill(-one(et), D+1)
-		coeff[D+1] = one(et)
-	elseif is_n_cube(p)
-		# x_1x_2...x_D(1-x_1)(1-x_2)...(1-x_D)
-		terms = Vector{CartesianIndex{D}}(undef, 2^D)
-		coeff = Vector{et}(undef, 2^D)
-		offset = 1
-		# Loop through all terms in the binomial expansion.
-		@inbounds for n ∈ 0:D
-			sign = (-one(et))^n
-			for idx ∈ combinations(1:D, n)
-				terms[offset] = CartesianIndex(ntuple(i -> i in idx ? 3 : 2, Val{D}()))
-				coeff[offset] = sign
-				offset += 1
-			end
-		end
-	else
-		@notimplemented
-	end
+  et = eltype(T)
+  if is_simplex(p)
+    # x_1x_2...x_D(1-x_1-x_2-...-x_D)
+    terms = Vector{CartesianIndex{D}}(undef, D+1)
+    @inbounds for j ∈ 1:D
+      # x_1x_2...x_{j-1}(x_j^2)x_{j+1}...x_D
+      terms[j] = CartesianIndex(ntuple(i->i==j ? 3 : 2, Val{D}()))
+    end
+    # x_1x_2...x_D
+    terms[D+1] = CartesianIndex(tfill(2, Val{D}()))
+    coeff = fill(-one(et), D+1)
+    coeff[D+1] = one(et)
+  elseif is_n_cube(p)
+    # x_1x_2...x_D(1-x_1)(1-x_2)...(1-x_D)
+    terms = Vector{CartesianIndex{D}}(undef, 2^D)
+    coeff = Vector{et}(undef, 2^D)
+    offset = 1
+    # Loop through all terms in the binomial expansion.
+    @inbounds for n ∈ 0:D
+      sign = (-one(et))^n
+      for idx ∈ combinations(1:D, n)
+        terms[offset] = CartesianIndex(ntuple(i -> i in idx ? 3 : 2, Val{D}()))
+        coeff[offset] = sign
+        offset += 1
+      end
+    end
+  else
+    @notimplemented
+  end
 
-	N = num_components(T)
-	coeffs = zeros(et, length(coeff) * N, N)
-	@inbounds for i ∈ axes(coeffs, 2)
-		coeffs[i:N:end, i] = coeff
-	end
+  N = num_components(T)
+  coeffs = zeros(et, length(coeff) * N, N)
+  @inbounds for i ∈ axes(coeffs, 2)
+    coeffs[i:N:end, i] = coeff
+  end
 
-	return terms, coeffs
+  return terms, coeffs
 end
 
 

--- a/src/ReferenceFEs/BubbleRefFEs.jl
+++ b/src/ReferenceFEs/BubbleRefFEs.jl
@@ -1,17 +1,40 @@
+"""
+    struct Bubble <: ReferenceFEName
+"""
 struct Bubble <: ReferenceFEName end
+
+"""
+    const bubble = Bubble()
+
+Singleton of the [`Bubble`](@ref) reference FE name.
+"""
 const bubble = Bubble()
 
+"""
+    BubbleRefFE(::Type{T}, p::Polytope{D}; type = :mini, coeffs = nothing, terms = nothing)
+
+A Lagrangian bubble space used to enrich another element.
+It contains `num_independent_components(T)` shape functions.
+
+By default -- `type == :mini` -- this is the bubble for (ℙ1ᴰb–ℙ1) MINI element (with shape
+functions of degree 3), it is available for simplices and n-cubes.
+
+If `coeffs` and `terms` are given, the bubble shape functions are defined by the
+[`linear_combination`](@ref) of the weight matrix `coeffs` with the
+[`MonomialBasis`](@ref) defined by `terms`.
+"""
 function BubbleRefFE(::Type{T}, p::Polytope{D}; type = :mini, coeffs = nothing, terms = nothing) where {T, D}
-  @notimplementedif D < 1 "Bubble reference finite elements are only defined for D >= 1."
+  @notimplementedif D < 1 "Bubble reference finite elements are only defined for `D >= 1`."
 
   if isnothing(coeffs) && isnothing(terms)
     if type == :mini
+      @notimplementedif !is_simplex(p) && !is_n_cube(p) "`:mini` element only implemented for simplices and n-cubes."
       terms, coeffs = _mini_bubble_terms_and_coeffs(T, p)
     else
-      @notimplemented "Only :mini is supported now; however, you may also specify `terms` and `coeffs` manually."
+      @notimplemented "Only `:mini` type is supported now; however, you may also specify `terms` and `coeffs` manually."
     end
   elseif isnothing(terms) || isnothing(coeffs)
-    @error "You must specify both `terms` and `coeffs` or neither."
+    @unreachable "You must specify both `terms` and `coeffs` or neither."
   end
 
   orders = Tuple(maximum(terms) - oneunit(eltype(terms)))
@@ -19,6 +42,10 @@ function BubbleRefFE(::Type{T}, p::Polytope{D}; type = :mini, coeffs = nothing, 
   x0 = mean(get_vertex_coordinates(p))
   dofs = LagrangianDofBasis(T, [x0])
   ndofs = length(dofs)
+
+  msg =  "Wrong `terms` and/or `coeffs`, the current implementation assumes that the bubble space contains `num_indep_component(T)` shapefunctions, T=$T"
+  @notimplementedif length(prebasis) != ndofs msg
+
   face_dofs = [Int[] for _ in 1:num_faces(p)]
   face_dofs[end] = 1:ndofs
   shapefuncs = compute_shapefuns(dofs, prebasis)
@@ -37,10 +64,17 @@ function BubbleRefFE(::Type{T}, p::Polytope{D}; type = :mini, coeffs = nothing, 
   )
 end
 
-get_order(reffe::GenericRefFE{Bubble}) = num_vertices(reffe.polytope)
-
-function ReferenceFE(p::Polytope, ::Bubble, ::Type{T}; kwargs...) where {T}
-  return BubbleRefFE(T, p; kwargs...)
+function ReferenceFE(p::Polytope, ::Bubble, ::Type{T}, order::Int;
+                     type = :mini, coeffs = nothing, terms = nothing) where {T}
+  if  isnothing(terms)
+    if type == :mini
+      @notimplementedif order ≠ 1 "The MINI bubble is only implemented for order 1 (ℙ1ᴰ+b–ℙ1) element."
+    end
+  else
+    max_orders = Tuple(maximum(Tuple(term), init=1) - 1 for term in terms)
+    @check order == maximum(max_orders, init=0) "`order` is not consistent with the given monomial `terms`."
+  end
+  return BubbleRefFE(T, p; type, coeffs, terms)
 end
 
 function _mini_bubble_terms_and_coeffs(::Type{T}, p::Polytope{D}) where {T, D}
@@ -74,7 +108,7 @@ function _mini_bubble_terms_and_coeffs(::Type{T}, p::Polytope{D}) where {T, D}
     @notimplemented
   end
 
-  N = num_components(T)
+  N = num_indep_components(T)
   coeffs = zeros(et, length(coeff) * N, N)
   @inbounds for i ∈ axes(coeffs, 2)
     coeffs[i:N:end, i] = coeff
@@ -82,5 +116,4 @@ function _mini_bubble_terms_and_coeffs(::Type{T}, p::Polytope{D}) where {T, D}
 
   return terms, coeffs
 end
-
 

--- a/src/ReferenceFEs/HHJRefFEs.jl
+++ b/src/ReferenceFEs/HHJRefFEs.jl
@@ -52,10 +52,6 @@ function HellanHerrmannJhonsonRefFE(::Type{T},p::Polytope,order::Integer) where 
   return MomentBasedReferenceFE(HellanHerrmannJhonson(),p,prebasis,moments,DivConformity())
 end
 
-# TODO remove those
-Polynomials.get_order(f::Fields.LinearCombinationFieldVector) = get_order(f.fields)
-Polynomials.get_order(f::AbstractVector{<:ConstantField}) = 0
-
 function ReferenceFE(p::Polytope,::HellanHerrmannJhonson,::Type{T}, order) where T
   HellanHerrmannJhonsonRefFE(T,p,order)
 end

--- a/test/GridapTests/StokesMiniTests.jl
+++ b/test/GridapTests/StokesMiniTests.jl
@@ -27,7 +27,7 @@ add_tag_from_tags!(labels, "dirichlet", [1, 2, 5])
 add_tag_from_tags!(labels, "neumann", [3, 4, 6, 7, 8])
 
 reffe_u = ReferenceFE(lagrangian, VectorValue{2, Float64}, 1)
-reffe_b = ReferenceFE(bubble, VectorValue{2, Float64})
+reffe_b = ReferenceFE(bubble, VectorValue{2, Float64}, 1)
 reffe_p = ReferenceFE(lagrangian, Float64, 1)
 
 V = TestFESpace(model, reffe_u, labels = labels, dirichlet_tags = "dirichlet", conformity = :H1)

--- a/test/ReferenceFEsTests/BubbleRefFEsTests.jl
+++ b/test/ReferenceFEsTests/BubbleRefFEsTests.jl
@@ -11,42 +11,42 @@ using Gridap.Arrays: evaluate
 # mini bubble tests
 et = Float64
 for p in [SEGMENT, TRI, QUAD, TET, HEX]
-	for T in [et, VectorValue{2, et}, VectorValue{3, et}]
-		reffe = BubbleRefFE(T, p)
-		test_reference_fe(reffe)
+  for T in [et, VectorValue{2, et}, VectorValue{3, et}]
+    reffe = BubbleRefFE(T, p)
+    test_reference_fe(reffe)
 
-		N = num_components(T)
-		@test num_dofs(reffe) == N
-		@test Conformity(reffe) == L2Conformity()
-		@test get_polytope(reffe) == p
+    N = num_components(T)
+    @test num_dofs(reffe) == N
+    @test Conformity(reffe) == L2Conformity()
+    @test get_polytope(reffe) == p
 
-		face_dofs = fill(Int[], num_faces(p))
-		face_dofs[end] = 1:N
-		@test get_face_dofs(reffe) == face_dofs
+    face_dofs = fill(Int[], num_faces(p))
+    face_dofs[end] = 1:N
+    @test get_face_dofs(reffe) == face_dofs
 
-		prebasis = get_prebasis(reffe)
-		@test length(prebasis) == N
-		@test prebasis isa LinearCombinationFieldVector
+    prebasis = get_prebasis(reffe)
+    @test length(prebasis) == N
+    @test prebasis isa LinearCombinationFieldVector
 
-		shapefuns = get_shapefuns(reffe)
-		@test length(shapefuns) == N
+    shapefuns = get_shapefuns(reffe)
+    @test length(shapefuns) == N
 
-		dofs = get_dof_basis(reffe)
-		xs = get_face_coordinates(p)
-		bxs = map(mean, xs)
-		bx0 = bxs[end]
-		# dof is at the barycenter of the polytope
-		for dof in dofs
-			@test bx0 == dof.point
-		end
-		# equal to 1 at the barycenter
-		val = evaluate(dofs, shapefuns)
-		@test val == one(val)
+    dofs = get_dof_basis(reffe)
+    xs = get_face_coordinates(p)
+    bxs = map(mean, xs)
+    bx0 = bxs[end]
+    # dof is at the barycenter of the polytope
+    for dof in dofs
+      @test bx0 == dof.point
+    end
+    # equal to 1 at the barycenter
+    val = evaluate(dofs, shapefuns)
+    @test val == one(val)
 
-		# equal to 0 at the barycenters of each d < D faces
-		vals = evaluate(shapefuns, bxs[1:(end-1)])
-		@test all(vals .== zero(T))
-	end
+    # equal to 0 at the barycenters of each d < D faces
+    vals = evaluate(shapefuns, bxs[1:(end-1)])
+    @test all(vals .== zero(T))
+  end
 end
 
 # specific tests for TRI


### PR DESCRIPTION
Various API improvements, doc and bugfixes on BubbleRefFE.

I fixed all documentation links and took the liberty to remove `:cross_references` from the makedocs warnonly, so that the CI now fails when we don't document new exported symbols (if its not wanted I can revert this).

@DimhamT if you don't mind reviewing the doc I wrote to check if it corresponds to what is implemented. Also if you happen to have references for all implemented MINI bubbles I would be happy to add them.