### PR TITLE
Add eigen function support for TensorValue

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added extension for `TikzPictures.jl`. Since PR[#1150](https://github.com/gridap/Gridap.jl/pull/1150).
+- Added `eigen` function support for `TensorValue` objects. Fixes issue [#1156](https://github.com/gridap/Gridap.jl/issues/1156). Since PR[#1157](https://github.com/gridap/Gridap.jl/pull/1157).
 
 ## [0.19.4] - 2025-08-09
 

--- a/src/TensorValues/Operations.jl
+++ b/src/TensorValues/Operations.jl
@@ -747,6 +747,14 @@ function inv(a::MultiValue{Tuple{3,3}})
  TensorValue{3}(data)
 end
 
+"""
+    eigen(a::MultiValue{Tuple{D,D}})
+
+Eigenvalue decomposition of a square second order tensor.
+"""
+eigen(a::MultiValue{Tuple{D,D}}) where D = eigen(get_array(a))
+eigen(a::MultiValue) = @unreachable "eigen undefined for this tensor shape: $(size(a))"
+
 ###############################################################
 # Measure
 ###############################################################

--- a/src/TensorValues/TensorValues.jl
+++ b/src/TensorValues/TensorValues.jl
@@ -91,9 +91,9 @@ import Base: adjoint
 import Base: transpose
 import Base: rand
 
-import LinearAlgebra: det, inv, tr, cross, dot, norm
+import LinearAlgebra: det, inv, tr, cross, dot, norm, eigen
 # Reexport from LinearAlgebra (just for convenience)
-export det, inv, tr, cross, dot, norm, ×, ⋅
+export det, inv, tr, cross, dot, norm, eigen, ×, ⋅
 
 import Gridap.Arrays: get_array
 

--- a/test/TensorValuesTests/OperationsTests.jl
+++ b/test/TensorValuesTests/OperationsTests.jl
@@ -620,6 +620,44 @@ t = TensorValue{2,3}(1:6...)
 @test_throws ErrorException det(t)
 @test_throws ErrorException inv(t)
 
+# Test eigen function
+t = TensorValue(1.0,2.0,3.0,4.0)
+result = eigen(t)
+expected = eigen(get_array(t))
+@test result.values ≈ expected.values
+@test result.vectors ≈ expected.vectors
+
+# Test different tensor types with eigen
+st = SymTensorValue(9.0,8.0,7.0,5.0,4.0,1.0)
+result_st = eigen(st)
+expected_st = eigen(get_array(st))
+@test result_st.values ≈ expected_st.values
+@test result_st.vectors ≈ expected_st.vectors
+
+qt = SymTracelessTensorValue(9.0,8.0,7.0,5.0,4.0)
+result_qt = eigen(qt)
+expected_qt = eigen(get_array(qt))
+@test result_qt.values ≈ expected_qt.values
+@test result_qt.vectors ≈ expected_qt.vectors
+
+# Test 1x1 case
+t1 = TensorValue(5.0)
+result1 = eigen(t1)
+expected1 = eigen(get_array(t1))
+@test result1.values ≈ expected1.values
+@test result1.vectors ≈ expected1.vectors
+
+# Test 3x3 case
+t3 = TensorValue(1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,10.0)
+result3 = eigen(t3)
+expected3 = eigen(get_array(t3))
+@test result3.values ≈ expected3.values
+@test result3.vectors ≈ expected3.vectors
+
+# Test error handling for non-square matrices
+t_nonsquare = TensorValue{2,3}(1:6...)
+@test_throws ErrorException eigen(t_nonsquare)
+
 # Measure
 
 a = VectorValue(1,2,3)


### PR DESCRIPTION
Fixes issue #1156 where eigen() function did not work correctly with TensorValue objects.

The implementation follows the same pattern as other LinearAlgebra operations like det() and inv() by using get_array() to convert to StaticArrays format and delegating to the optimized StaticArrays eigen implementation.
