### PR TITLE
Added isapprox support for MultiValue

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added extension for `TikzPictures.jl`. Since PR[#1150](https://github.com/gridap/Gridap.jl/pull/1150).
 - Added `eigen` function support for `TensorValue` objects. Fixes issue [#1156](https://github.com/gridap/Gridap.jl/issues/1156). Since PR[#1157](https://github.com/gridap/Gridap.jl/pull/1157).
+- Added `isapprox` function support for `TensorValue` objects. Since PR[1158](https://github.com/gridap/Gridap.jl/pull/1158)
 
 ## [0.19.4] - 2025-08-09
 

--- a/src/TensorValues/Operations.jl
+++ b/src/TensorValues/Operations.jl
@@ -5,10 +5,10 @@
 (==)(a::MultiValue,b::MultiValue) = false
 (==)(a::MultiValue{S},b::MultiValue{S}) where {S} = a.data == b.data
 isapprox(a::MultiValue,b::MultiValue;kwargs...) = isapprox(get_array(a),get_array(b);kwargs...)
-(≈)(a::MultiValue{S,T1,N,0} where T1,b::MultiValue{S,T2,N,0} where T2;kwargs...) where {S,N} = true
+isapprox(a::MultiValue{S,T1,N,0} where T1,b::MultiValue{S,T2,N,0} where T2;kwargs...) where {S,N} = true
 
-function (≈)(
-  a::AbstractArray{<:MultiValue}, b::AbstractArray{<:MultiValue})
+function isapprox(
+  a::AbstractArray{<:MultiValue}, b::AbstractArray{<:MultiValue};kwargs...)
   if size(a) != size(b); return false; end
   for (ai,bi) in zip(a,b)
     if !(ai≈bi); return false; end

--- a/src/TensorValues/Operations.jl
+++ b/src/TensorValues/Operations.jl
@@ -6,6 +6,7 @@
 (==)(a::MultiValue{S},b::MultiValue{S}) where {S} = a.data == b.data
 (≈)(a::MultiValue{S},b::MultiValue{S}) where {S} = isapprox(get_array(a), get_array(b))
 (≈)(a::MultiValue{S,T1,N,0} where T1,b::MultiValue{S,T2,N,0} where T2) where {S,N} = true
+isapprox(a::MultiValue,b::MultiValue;kwargs...) = isapprox(get_array(a),get_array(b);kwargs...)
 
 function (≈)(
   a::AbstractArray{<:MultiValue}, b::AbstractArray{<:MultiValue})
@@ -31,8 +32,6 @@ end
 
 isless(a::Number,b::MultiValue) = all(isless.(a, b.data))
 isless(a::MultiValue,b::MultiValue) = @unreachable "Comparison is not defined between tensor of order greater than 1"
-
-isapprox(a::MultiValue,b::MultiValue;kwargs...) = isapprox(get_array(a),get_array(b);kwargs...)
 
 ###############################################################
 # Addition / subtraction

--- a/src/TensorValues/Operations.jl
+++ b/src/TensorValues/Operations.jl
@@ -5,6 +5,7 @@
 (==)(a::MultiValue,b::MultiValue) = false
 (==)(a::MultiValue{S},b::MultiValue{S}) where {S} = a.data == b.data
 isapprox(a::MultiValue,b::MultiValue;kwargs...) = isapprox(get_array(a),get_array(b);kwargs...)
+(≈)(a::MultiValue{S,T1,N,0} where T1,b::MultiValue{S,T2,N,0} where T2;kwargs...) where {S,N} = true
 
 function (≈)(
   a::AbstractArray{<:MultiValue}, b::AbstractArray{<:MultiValue})

--- a/src/TensorValues/Operations.jl
+++ b/src/TensorValues/Operations.jl
@@ -4,13 +4,13 @@
 
 (==)(a::MultiValue,b::MultiValue) = false
 (==)(a::MultiValue{S},b::MultiValue{S}) where {S} = a.data == b.data
-(≈)(a::MultiValue,b::MultiValue;kwargs...) = (≈)(get_array(a),get_array(b);kwargs...)
+(≈)(a::MultiValue,b::MultiValue;kwargs...) = ≈(get_array(a),get_array(b);kwargs...)
 
 function (≈)(
   a::AbstractArray{<:MultiValue}, b::AbstractArray{<:MultiValue}; kwargs...)
   if size(a) != size(b); return false; end
   for (ai,bi) in zip(a,b)
-    if !(≈)(ai,bi;kwargs...); return false; end
+    if !≈(ai,bi;kwargs...); return false; end
   end
   true
 end

--- a/src/TensorValues/Operations.jl
+++ b/src/TensorValues/Operations.jl
@@ -11,7 +11,7 @@ function isapprox(
   a::AbstractArray{<:MultiValue}, b::AbstractArray{<:MultiValue};kwargs...)
   if size(a) != size(b); return false; end
   for (ai,bi) in zip(a,b)
-    if !(ai≈bi); return false; end
+    if !isapprox(ai,bi;kwargs...); return false; end
   end
   true
 end

--- a/src/TensorValues/Operations.jl
+++ b/src/TensorValues/Operations.jl
@@ -4,8 +4,6 @@
 
 (==)(a::MultiValue,b::MultiValue) = false
 (==)(a::MultiValue{S},b::MultiValue{S}) where {S} = a.data == b.data
-(≈)(a::MultiValue{S},b::MultiValue{S}) where {S} = isapprox(get_array(a), get_array(b))
-(≈)(a::MultiValue{S,T1,N,0} where T1,b::MultiValue{S,T2,N,0} where T2) where {S,N} = true
 isapprox(a::MultiValue,b::MultiValue;kwargs...) = isapprox(get_array(a),get_array(b);kwargs...)
 
 function (≈)(

--- a/src/TensorValues/Operations.jl
+++ b/src/TensorValues/Operations.jl
@@ -32,6 +32,8 @@ end
 isless(a::Number,b::MultiValue) = all(isless.(a, b.data))
 isless(a::MultiValue,b::MultiValue) = @unreachable "Comparison is not defined between tensor of order greater than 1"
 
+isapprox(a::MultiValue,b::MultiValue;kwargs...) = isapprox(get_array(a),get_array(b);kwargs...)
+
 ###############################################################
 # Addition / subtraction
 ###############################################################

--- a/src/TensorValues/Operations.jl
+++ b/src/TensorValues/Operations.jl
@@ -4,14 +4,14 @@
 
 (==)(a::MultiValue,b::MultiValue) = false
 (==)(a::MultiValue{S},b::MultiValue{S}) where {S} = a.data == b.data
-isapprox(a::MultiValue,b::MultiValue;kwargs...) = isapprox(get_array(a),get_array(b);kwargs...)
-isapprox(a::MultiValue{S,T1,N,0} where T1,b::MultiValue{S,T2,N,0} where T2;kwargs...) where {S,N} = true
+(≈)(a::MultiValue,b::MultiValue;kwargs...) = (≈)(get_array(a),get_array(b);kwargs...)
+(≈)(a::MultiValue{S,T1,N,0} where T1,b::MultiValue{S,T2,N,0} where T2;kwargs...) where {S,N} = true
 
-function isapprox(
+function (≈)(
   a::AbstractArray{<:MultiValue}, b::AbstractArray{<:MultiValue};kwargs...)
   if size(a) != size(b); return false; end
   for (ai,bi) in zip(a,b)
-    if !isapprox(ai,bi;kwargs...); return false; end
+    if !(≈)(ai,bi;kwargs...); return false; end
   end
   true
 end

--- a/src/TensorValues/Operations.jl
+++ b/src/TensorValues/Operations.jl
@@ -5,10 +5,9 @@
 (==)(a::MultiValue,b::MultiValue) = false
 (==)(a::MultiValue{S},b::MultiValue{S}) where {S} = a.data == b.data
 (≈)(a::MultiValue,b::MultiValue;kwargs...) = (≈)(get_array(a),get_array(b);kwargs...)
-(≈)(a::MultiValue{S,T1,N,0} where T1,b::MultiValue{S,T2,N,0} where T2;kwargs...) where {S,N} = true
 
 function (≈)(
-  a::AbstractArray{<:MultiValue}, b::AbstractArray{<:MultiValue};kwargs...)
+  a::AbstractArray{<:MultiValue}, b::AbstractArray{<:MultiValue}; kwargs...)
   if size(a) != size(b); return false; end
   for (ai,bi) in zip(a,b)
     if !(≈)(ai,bi;kwargs...); return false; end

--- a/src/TensorValues/TensorValues.jl
+++ b/src/TensorValues/TensorValues.jl
@@ -78,7 +78,7 @@ export indep_components_names
 
 import Base: show
 import Base: zero, one
-import Base: +, -, *, /, \, ==, isless, isapprox
+import Base: +, -, *, /, \, ==, ≈, isless
 import Base: conj, real, imag
 import Base: sum, maximum, minimum
 import Base: getindex, iterate, eachindex, lastindex

--- a/src/TensorValues/TensorValues.jl
+++ b/src/TensorValues/TensorValues.jl
@@ -78,7 +78,7 @@ export indep_components_names
 
 import Base: show
 import Base: zero, one
-import Base: +, -, *, /, \, ==, ≈, isless
+import Base: +, -, *, /, \, ==, ≈, isless, isapprox
 import Base: conj, real, imag
 import Base: sum, maximum, minimum
 import Base: getindex, iterate, eachindex, lastindex

--- a/src/TensorValues/TensorValues.jl
+++ b/src/TensorValues/TensorValues.jl
@@ -78,7 +78,7 @@ export indep_components_names
 
 import Base: show
 import Base: zero, one
-import Base: +, -, *, /, \, ==, ≈, isless, isapprox
+import Base: +, -, *, /, \, ==, isless, isapprox
 import Base: conj, real, imag
 import Base: sum, maximum, minimum
 import Base: getindex, iterate, eachindex, lastindex

--- a/test/TensorValuesTests/OperationsTests.jl
+++ b/test/TensorValuesTests/OperationsTests.jl
@@ -33,6 +33,8 @@ b = VectorValue(1,3,3)
 @test isapprox(VectorValue(1,2,3), VectorValue(1.0,2.0,3.0))
 @test isapprox(VectorValue(1,2,3), VectorValue(1.0,2.0,3.0), atol=eps(1.0))
 @test isapprox(VectorValue(1,2,3), VectorValue(1.0,2.0,3.0), rtol=eps(1.0))
+@test !isapprox(VectorValue(1,2,3), VectorValue(1.0,2.0,4.0))
+@test_throws DimensionMismatch isapprox(VectorValue(1,2,3), VectorValue(1.0,2.0,3.0,4.0))
 
 a = VectorValue(1,2,3)
 b = VectorValue(2,1,6)

--- a/test/TensorValuesTests/OperationsTests.jl
+++ b/test/TensorValuesTests/OperationsTests.jl
@@ -70,6 +70,8 @@ r = VectorValue(-1,1,-3)
 
 a = VectorValue{0,Float64}()
 b = VectorValue{0,Int}()
+@test a == b
+@test a ≈ b
 
 c = +a
 r = VectorValue{0,Float64}()

--- a/test/TensorValuesTests/OperationsTests.jl
+++ b/test/TensorValuesTests/OperationsTests.jl
@@ -31,6 +31,8 @@ b = VectorValue(1,3,3)
 @test iszero(VectorValue(1,2,3) - VectorValue(1.0,2.0,3.0))
 @test iszero(zero(VectorValue(1,2,3)))
 @test isapprox(VectorValue(1,2,3), VectorValue(1.0,2.0,3.0))
+@test isapprox(VectorValue(1,2,3), VectorValue(1.0,2.0,3.0), atol=eps(1.0))
+@test isapprox(VectorValue(1,2,3), VectorValue(1.0,2.0,3.0), rtol=eps(1.0))
 
 a = VectorValue(1,2,3)
 b = VectorValue(2,1,6)


### PR DESCRIPTION
This PR is a proposal to extend the interface of `MultiValue`. Its implementation follows the pattern of #1157.

**Current behaviour**
Right now, the function `isapprox(::MultiValue, ::MultiValue)` is available with default arguments, but is not possible to pass optional arguments like tolerance.

**Proposed behaviour**
After this PR, it will be able to call the function `isapprox` with optional arguments, e.g. `isapprox(A,B,rtol=eps(1.0)`.