### PR TITLE
Get Dirichlet dof values

### DIFF
--- a/src/FESpaces/FESpaceInterface.jl
+++ b/src/FESpaces/FESpaceInterface.jl
@@ -50,6 +50,10 @@ function get_fe_space(f::FEFunction)
   @abstractmethod
 end
 
+function get_dirichlet_dof_values(f::FEFunction)
+  get_dirichlet_dof_values(get_fe_space(f))
+end
+
 function get_cell_is_dirichlet(f::FEFunction)
   get_cell_is_dirichlet(get_fe_space(f))
 end

--- a/test/FESpacesTests/TrialFESpacesTests.jl
+++ b/test/FESpacesTests/TrialFESpacesTests.jl
@@ -53,6 +53,8 @@ e = u - uh
 trian = Triangulation(model)
 quad = CellQuadrature(trian,order)
 
+@test get_dirichlet_dof_values(uh) ≈ [0.0, 1/3, 2/3, 1/6, 0.5, 5/6]
+
 el2 = sqrt(sum(integrate(inner(e,e),quad)))
 @test el2 < 1.0e-10
 


### PR DESCRIPTION
This PR adds an overload of `get_dirichlet_dof_values(f::FEFunction)` which forwards to `get_dirichlet_dof_values(get_fe_space(f))`.

Motivation: Other related functions (e.g., `get_free_dof_values`, `get_cell_is_dirichlet`) already accept a `FEFunction`. Adding this method makes the interface consistent.

Closes #1187 