### PR TITLE
Fix/ftc field cmaps index

### DIFF
--- a/src/Adaptivity/FineToCoarseFields.jl
+++ b/src/Adaptivity/FineToCoarseFields.jl
@@ -147,7 +147,7 @@ function Arrays.evaluate!(cache,a::FineToCoarseField,x::AbstractArray{<:Point},c
     field_id = id_map[child_id]
     if field_id != 0
       fi = getindex!(fi_cache,fields,field_id)
-      mi = getindex!(mi_cache,cmaps,field_id)
+      mi = getindex!(mi_cache,cmaps,child_id)
       zi = Fields.evaluate!(zi_cache,mi,xi)
       y[i] = Fields.evaluate!(yi_cache,fi,zi)
     end


### PR DESCRIPTION
### Description

This PR fixes incorrect inverse cell map indexing in the fast-path implementation of `FineToCoarseField.evaluate!` reported in #1223.

In `src/Adaptivity/FineToCoarseFields.jl` (line 150), the inverse cell map array `cmaps` was being indexed using `field_id`:

```julia
mi = getindex!(mi_cache, cmaps, field_id)
```

However, `cmaps = get_inverse_cell_map(rr)` contains one map per subcell of the refinement rule and must be indexed using `child_id`. `field_id` is the index into `fine_fields`, which may differ from the subcell index when not all children are locally present.

This PR updates the fast-path evaluation to use the correct index:

```julia
mi = getindex!(mi_cache, cmaps, child_id)
```

---

### Impact

This affects DOF evaluation on adapted meshes when only a subset of child cells is available (e.g. in distributed adaptive simulations using GridapP4est). Using the wrong inverse map during field evaluation can lead to incorrect DOF values without producing runtime errors.

---

### Fix

Use `child_id` instead of `field_id` when indexing `cmaps` in the fast-path evaluation. This matches the same fix already applied to the slow path in commit 76901ef1b.