### PR TITLE
Fix/issue 1224 mapped grid cell map

### DIFF
--- a/src/Geometry/MappedDiscreteModels.jl
+++ b/src/Geometry/MappedDiscreteModels.jl
@@ -55,6 +55,7 @@ get_node_coordinates(grid::MappedGrid) = grid.node_coords
 get_cell_node_ids(grid::MappedGrid) = get_cell_node_ids(grid.grid)
 get_reffes(grid::MappedGrid) = get_reffes(grid.grid)
 get_cell_type(grid::MappedGrid) = get_cell_type(grid.grid)
+get_cell_map(grid::MappedGrid) = grid.geo_map
 
 """
 MappedDiscreteModel


### PR DESCRIPTION
This PR fixes the issue reported in #1225 where `MappedGrid` does not override `get_cell_map`.

`MappedGrid` computes and stores the composed geometric map

```
geo_map = phys_map ∘ model_map
```

during construction. However, there was no `get_cell_map(grid::MappedGrid)` method returning this map. As a result, calls to `get_cell_map` fell back to the default implementation for `Grid`, which reconstructs the mapping using linear interpolation of the deformed node coordinates.

```julia
function get_cell_map(trian::Grid)
  cell_to_coords = get_cell_coordinates(trian)
  cell_to_shapefuns = get_cell_shapefuns(trian)
  lazy_map(linear_combination, cell_to_coords, cell_to_shapefuns)
end
```

This reconstruction is correct only when the physical mapping is linear. For nonlinear or curved mappings it produces a piecewise linear approximation instead of the composed map stored in `MappedGrid`.

---

### Impact

For grids created with a nonlinear `phys_map`, the fallback behavior may lead to incorrect geometric mappings during FE assembly. This affects quantities derived from the mapping such as Jacobians, integration weights, and gradient transformations.

As a result, FE operators assembled on a `MappedGrid` may use an approximate geometric map instead of the intended composed map.

---

### Fix

Return the stored composed map when `get_cell_map` is called on a `MappedGrid`:

```julia
get_cell_map(grid::MappedGrid) = grid.geo_map
```

---

### Summary of changes

- Added `get_cell_map(::MappedGrid)` in  
  `src/Geometry/MappedDiscreteModels.jl`
- The method returns the stored composed map (`geo_map`)
- Ensures `MappedGrid` provides the correct geometric mapping during FE computations