### PR TITLE
fix autodiff of functions requiring a VectorValue

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed type inference for operations between MultiValue types. Since PR[1270](https://github.com/gridap/Gridap.jl/pull/1270).
+- Allow autodifferentiation of functions that require a VectorValue input. Since PR[1271](https://github.com/gridap/Gridap.jl/pull/1271).
 
 ## [0.20.3] - 2026-03-23
 

--- a/src/Fields/AutoDiff.jl
+++ b/src/Fields/AutoDiff.jl
@@ -52,17 +52,17 @@ function gradient(f::Function,x::Point)
 end
 
 function gradient(f::Function,x::Point,fx::Number)
-  VectorValue(ForwardDiff.gradient(f,get_array(x)))
+  VectorValue(ForwardDiff.gradient(f∘Point,get_array(x)))
 end
 
 function gradient(f::Function,x::Point,fx::VectorValue)
-  TensorValue(transpose(ForwardDiff.jacobian(y->get_array(f(y)),get_array(x))))
+  TensorValue(transpose(ForwardDiff.jacobian(get_array∘f∘Point,get_array(x))))
 end
 
 # Implementation for all second order tensor values
 # Does not exploit possible symmetries
 function gradient(f::Function,x::Point{A},fx::S) where S<:MultiValue{Tuple{B,C}} where {A,B,C}
-  a = transpose(ForwardDiff.jacobian(y->get_array(f(y)),get_array(x)))
+  a = transpose(ForwardDiff.jacobian(get_array∘f∘Point,get_array(x)))
   ThirdOrderTensorValue(reshape(a, (A,B,C)))
 end
 
@@ -83,17 +83,17 @@ function divergence(f::Function,x::Point,fx::VectorValue)
 end
 
 function divergence(f::Function,x::Point{D},fx::S) where S<:MultiValue{Tuple{D,A},T} where {D,A,T}
-  a = ForwardDiff.jacobian(y->get_array(f(y)),get_array(x))
+  a = ForwardDiff.jacobian(get_array∘f∘Point,get_array(x))
   VectorValue{A,T}( ntuple(k -> sum(i-> a[(k-1)*D+i,i], 1:D),A) )
 end
 
 function divergence(f::Function,x::Point{D},fx::S) where S<:MultiValue{Tuple{D,A,B},T} where {D,A,B,T}
-  a = ForwardDiff.jacobian(y->get_array(f(y)),get_array(x))
+  a = ForwardDiff.jacobian(get_array∘f∘Point,get_array(x))
   TensorValue{A,B,T}( ntuple(k -> sum(i-> a[(k-1)*D+i,i], 1:D),A*B) )
 end
 
 function divergence(f::Function,x::Point,fx::TensorValue{2,2})
-  g(x) = SVector(f(x).data)
+  g(x) = SVector(f(Point(x)).data)
   a = ForwardDiff.jacobian(g,get_array(x))
   VectorValue(
     a[1,1]+a[2,2],
@@ -102,7 +102,7 @@ function divergence(f::Function,x::Point,fx::TensorValue{2,2})
 end
 
 function divergence(f::Function,x::Point,fx::TensorValue{3,3})
-  g(x) = SVector(f(x).data)
+  g(x) = SVector(f(Point(x)).data)
   a = ForwardDiff.jacobian(g,get_array(x))
   VectorValue(
     a[1,1]+a[2,2]+a[3,3],
@@ -112,7 +112,7 @@ function divergence(f::Function,x::Point,fx::TensorValue{3,3})
 end
 
 function divergence(f::Function,x::Point{2},fx::AbstractSymTensorValue{2})
-  g(x) = SVector(f(x).data)
+  g(x) = SVector(f(Point(x)).data)
   a = ForwardDiff.jacobian(g,get_array(x))
   VectorValue(
     a[1,1]+a[2,2],
@@ -121,7 +121,7 @@ function divergence(f::Function,x::Point{2},fx::AbstractSymTensorValue{2})
 end
 
 function divergence(f::Function,x::Point{3},fx::AbstractSymTensorValue{3})
-  g(x) = SVector(f(x).data)
+  g(x) = SVector(f(Point(x)).data)
   a = ForwardDiff.jacobian(g,get_array(x))
   VectorValue(
     a[1,1]+a[2,2]+a[3,3],
@@ -143,18 +143,18 @@ function laplacian(f::Function,x::Point)
 end
 
 function laplacian(f::Function,x::Point,fx::Number)
-  tr(ForwardDiff.jacobian(y->ForwardDiff.gradient(f,y), get_array(x)))
+  tr(ForwardDiff.jacobian(y->ForwardDiff.gradient(f∘Point,y), get_array(x)))
 end
 
 function laplacian(f::Function,x::Point{A},fx::VectorValue{B,T}) where {A,B,T}
   a = MMatrix{A*B,A,T}(undef)
-  ForwardDiff.jacobian!(a, y->ForwardDiff.jacobian(z->get_array(f(z)),y), get_array(x))
+  ForwardDiff.jacobian!(a, y->ForwardDiff.jacobian(get_array∘f∘Point,y), get_array(x))
   VectorValue{B,T}( ntuple(k -> sum(i-> a[(i-1)*B+k,i], 1:A),B) )
 end
 
 function laplacian(f::Function,x::Point{A},fx::S) where S<:MultiValue{Tuple{B,C},T} where {A,B,C,T}
   a = MMatrix{A*B*C,A,T}(undef)
-  ForwardDiff.jacobian!(a, y->ForwardDiff.jacobian(z->get_array(f(z)),y), get_array(x))
+  ForwardDiff.jacobian!(a, y->ForwardDiff.jacobian(get_array∘f∘Point,y), get_array(x))
   t = ntuple(k -> sum(i-> a[(i-1)*B*C+k,i], 1:A),B*C)
   S(SMatrix{B,C}(t)) #Necessary cast to build e.g. symmetric tensor values
 end
@@ -162,7 +162,7 @@ end
 # Implementation for any third order tensor values
 function laplacian(f::Function,x::Point{A},fx::S) where S<:MultiValue{Tuple{B,C,D},T} where {A,B,C,D,T}
   a = MMatrix{A*B*C*D,A,T}(undef)
-  ForwardDiff.jacobian!(a, y->ForwardDiff.jacobian(z->get_array(f(z)),y), get_array(x))
+  ForwardDiff.jacobian!(a, y->ForwardDiff.jacobian(get_array∘f∘Point,y), get_array(x))
   t = ntuple(k -> sum(i-> a[(i-1)*B*C*D+k,i], 1:A),B*C*D)
   S(SArray{Tuple{B,C,D}}(t))
 end

--- a/test/FieldsTests/DiffOperatorsTests.jl
+++ b/test/FieldsTests/DiffOperatorsTests.jl
@@ -167,6 +167,29 @@ for x in xs
   @test (∇⋅εu)(x) == VectorValue(4.,0.)
 end
 
+x0 = VectorValue(-0.3, 0.5)
+A = TensorValue(0.0, -1.0, 1.0, 0.0)
+u(x) = (x - x0) ⋅ A
+∇u(x) = A
+Δu(x) = VectorValue(0.0, 0.0)
+
+for x in xs
+  @test ∇(u)(x) == ∇u(x)
+  @test Δ(u)(x) == Δu(x)
+  @test Δ(u)(x) == (∇⋅∇u)(x)
+end
+
+x0 = VectorValue(1.0, 0.5)
+u(x) = exp(-(x - x0) ⋅ (x - x0))
+∇u(x) = -2(x - x0) * u(x)
+Δu(x) = 4u(x) * ((x - x0) ⋅ (x - x0) - 1)
+
+for x in xs
+  @test ∇(u)(x) == ∇u(x)
+  @test Δ(u)(x) == Δu(x)
+  @test Δ(u)(x) == (∇⋅∇u)(x)
+end
+
 u(x) = VectorValue( x[1]^2 + 2*x[3]^2, -x[1]^2, -x[2]^2 + x[3]^2 )
 ∇u(x) = TensorValue( 2*x[1],0,4*x[3],  -2*x[1],0,0,  0,-2*x[2],2*x[3] )
 Δu(x) = VectorValue( 6, -2, 0 )
@@ -183,6 +206,28 @@ for x in xs
   @test Fields.skew_symmetric_gradient(u)(x) == νu(x)
   @test Δ(u)(x) == (∇⋅∇u)(x)
   @test (∇⋅εu)(x) == VectorValue(4.,-1.,1.)
+end
+
+v = VectorValue(0.5, -1.0, 2.0)
+x0 = VectorValue(0.3, 1.0, -0.2)
+u(x) = (x - x0) × v + v ⋅ (x ⊗ x)
+∇u(x) = (
+  TensorValue([0.0 -v[3] v[2]; v[3] 0.0 -v[1]; -v[2] v[1] 0.0])
+  + v ⊗ x + v ⋅ x * TensorValue(Matrix(I,3,3))
+)
+Δu(x) = 2v
+εu(x) = symmetric_part(∇u(x))
+νu(x) = TensorValues.skew_symmetric_part(∇u(x))
+
+xs = [ Point(1.,1.,2.0), Point(2.,0.,1.), Point(0.,3.,0.), Point(-1.,3.,2.)]
+for x in xs
+  @test ∇(u)(x) == ∇u(x)
+  @test (∇⋅u)(x) == tr(∇u(x))
+  @test (∇×u)(x) == grad2curl(∇u(x))
+  @test Δ(u)(x) == Δu(x)
+  @test ε(u)(x) == εu(x)
+  @test Fields.skew_symmetric_gradient(u)(x) == νu(x)
+  @test Δ(u)(x) == (∇⋅∇u)(x)
 end
 
 end # module


### PR DESCRIPTION
Autodifferentiating functions that require a `VectorValue` as input causes an error because the autodiff routines pass in an `SVector` instead.

For example, running
```julia
begin
	x₀ = VectorValue(1.0, 2.0)
	f(x) = (x - x₀) ⋅ (x - x₀)
	∇(f)(VectorValue(1.0, 2.0) + x₀)
end
```
results in
```julia
ERROR: MethodError: no method matching -(::StaticArraysCore.SVector{2, ForwardDiff.Dual{ForwardDiff.Tag{…}, Float64, 2}}, ::VectorValue{2, Float64})
For element-wise subtraction, use broadcasting with dot syntax: array .- scalar
The function `-` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  -(::Missing, ::Number)
   @ Base missing.jl:123
  -(::typeof(gradient), ::VectorValue)
   @ Gridap ~/.julia/packages/Gridap/cvsif/src/Fields/DiffOperators.jl:167
  -(::V, ::V) where V<:Gridap.TensorValues.MultiValue
   @ Gridap ~/.julia/packages/Gridap/cvsif/src/TensorValues/Operations.jl:94
  ...

Stacktrace:
 [1] f(x::StaticArraysCore.SVector{2, ForwardDiff.Dual{ForwardDiff.Tag{typeof(f), Float64}, Float64, 2}})
   @ Main ./REPL[2]:3
```

After this patch, I get
```
VectorValue{2, Float64}(2.0, 4.0)
```