### PR TITLE
[Fix]: Check convergence in NLSolver before returning solution

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `NLSolver` now checks convergence status before returning solution. Previously, when `nlsolve()` failed to converge, the unconverged last iterate was silently returned. Now throws an informative error with iteration count and residual norm. Since PR[#1283](https://github.com/gridap/Gridap.jl/pull/1283). (@Ady0333)
+
 ## [0.20.4] - 2026-04-23
 
 ### Added

--- a/src/Algebra/NLSolvers.jl
+++ b/src/Algebra/NLSolvers.jl
@@ -149,6 +149,9 @@ function _nlsolve_with_updated_cache!(x,nls,op,cache)
   end
   r = nlsolve(df,x;linsolve=linsolve!,kwargs...)
   cache.result = r
+  if !converged(r)
+    error("Newton solver did not converge after $(r.iterations) iterations. Final residual norm: $(r.residual_norm)")
+  end
   copy_entries!(x,r.zero)
 end
 

--- a/src/ODEs/StageOperators.jl
+++ b/src/ODEs/StageOperators.jl
@@ -190,6 +190,9 @@ function Algebra._nlsolve_with_updated_cache!(
 
   result = nlsolve(cache.df, x; linsolve=linsolve!, nls.kwargs...)
   cache.result = result
+  if !converged(result)
+    error("Newton solver did not converge after $(result.iterations) iterations. Final residual norm: $(result.residual_norm)")
+  end
   copy_entries!(x, result.zero)
 end
 


### PR DESCRIPTION
## Summary

Fixes #1282 

When `nlsolve()` fails to converge, NLSolver now checks the convergence status before returning the solution. Previously, it silently copied the unconverged last iterate.

---

## Changes

- `src/Algebra/NLSolvers.jl`: Add `converged()` check after `nlsolve()` call
- `src/ODEs/StageOperators.jl`: Same fix for ODE/transient context

---

## Behavior

**Before:** Unconverged Newton iterates silently returned as valid solutions
**After:** Throws error with iteration count and residual norm

---

## Testing

Tested with a nonlinear problem that fails to converge:
- Previously: returned x=44.44 (wrong) with no error
- Now: throws "Newton solver did not converge after 5 iterations. Final residual norm: 87788"

All existing Gridap tests pass.