### PR TITLE
[Fix]: NewtonRaphsonSolver convergence check and error handling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `NewtonRaphsonSolver` now correctly handles already-converged initial states and reports non-convergence properly. Previously crashed with `@unreachable` when starting residual was ~0. Now checks initial convergence and throws informative error instead of assertion failure. Since PR[#1285](https://github.com/gridap/Gridap.jl/pull/1285). (@Ady0333)
+
 ## [0.20.4] - 2026-04-23
 
 ### Added

--- a/src/Algebra/NLSolvers.jl
+++ b/src/Algebra/NLSolvers.jl
@@ -64,7 +64,7 @@ function _solve_nr!(x,A,b,dx,ns,nls,op)
     if isconv; return; end
 
     if nliter == nls.max_nliters
-      @unreachable
+      error("NewtonRaphsonSolver failed to converge in $(nls.max_nliters) iterations. Final residual: $(maximum(abs,b))")
     end
 
     # Assemble jacobian (fast in-place version)
@@ -78,7 +78,7 @@ end
 
 function _check_convergence(nls,b)
   m0 = maximum(abs,b)
-  return (false, m0)
+  return (m0 < nls.tol, m0)
 end
 
 function _check_convergence(nls,b,m0)


### PR DESCRIPTION
## Summary

Fixes #1284 

Two related fixes for NewtonRaphsonSolver:

1. **Initial convergence check** - Actually test if starting residual is below tolerance
2. **Error handling** - Replace `@unreachable` with informative error message

---

## Changes

In `src/Algebra/NLSolvers.jl`:

**Line 81** - Initial check:
```julia
# Before: return (false, m0)
# After:  return (m0 < nls.tol, m0)
```

**Line 67** - Non-convergence handling:
```julia
# Before: @unreachable
# After:  error("NewtonRaphsonSolver failed to converge in $(nls.max_nliters) iterations. Final residual: $m")
```

---

## Behavior

**Before:**
- Starting from converged state → crash with "@unreachable"
- Relative tolerance `m < tol*m0` unsatisfiable when `m0 ≈ 0`

**After:**
- Already-converged initial state → exits immediately
- Non-convergence → informative error with diagnostics

---

## Testing

Tested with Newton starting at exact solution (zero residual):
- Previously: crashed with "@unreachable"
- Now: exits cleanly on first convergence check

All existing Gridap tests pass.

---

## Related

Related to #1282  - part of broader Newton solver convergence testing