### PR TITLE
Bugfix on basis type instability

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed type instability for tensor operations between `MultiValue` and scalars. Since PR[#1293](https://github.com/gridap/Gridap.jl/pull/1293).
+- Fixed type instability in basis construction when user gives a non-concrete output type. Since PR[#1294](https://github.com/gridap/Gridap.jl/pull/1294).
 
 ## [0.20.5] - 2026-04-28
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Make `compute_facet_owners(...)` more flexible, allowing the user to provide a function to select the owner from neighboring cells. Since PR[#1291](https://github.com/gridap/Gridap.jl/pull/1291).
+
+### Fixed
+
+- Fixed type instability for tensor operations between `MultiValue` and scalars. Since PR[#1293](https://github.com/gridap/Gridap.jl/pull/1293).
 
 ## [0.20.5] - 2026-04-28
 

--- a/src/Polynomials/BernsteinBases.jl
+++ b/src/Polynomials/BernsteinBases.jl
@@ -247,8 +247,7 @@ struct BernsteinBasisOnSimplex{D,V,M,K} <: PolynomialBasis{D,V,Bernstein}
   function BernsteinBasisOnSimplex{D}(::Type{V},order::Int,vertices=nothing) where {D,V}
     _simplex_vertices_checks(Val(D), vertices)
 
-    VV = ifelse(isconcretetype(V),V,typeof(zero(V)))
-    @check isconcretetype(VV) "Trying to build BernsteinBasisOnSimplex with non-concrete output type $(VV)"
+    VV = make_concretetype(V)
     cart_to_bary_matrix = _compute_cart_to_bary_matrix(vertices, Val(D+1))
     M = typeof(cart_to_bary_matrix) # Nothing or SMatrix
     K = order

--- a/src/Polynomials/BernsteinBases.jl
+++ b/src/Polynomials/BernsteinBases.jl
@@ -247,10 +247,12 @@ struct BernsteinBasisOnSimplex{D,V,M,K} <: PolynomialBasis{D,V,Bernstein}
   function BernsteinBasisOnSimplex{D}(::Type{V},order::Int,vertices=nothing) where {D,V}
     _simplex_vertices_checks(Val(D), vertices)
 
+    VV = ifelse(isconcretetype(V),V,typeof(zero(V)))
+    @check isconcretetype(VV) "Trying to build BernsteinBasisOnSimplex with non-concrete output type $(VV)"
     cart_to_bary_matrix = _compute_cart_to_bary_matrix(vertices, Val(D+1))
     M = typeof(cart_to_bary_matrix) # Nothing or SMatrix
     K = order
-    new{D,V,M,K}(cart_to_bary_matrix)
+    new{D,VV,M,K}(cart_to_bary_matrix)
   end
 end
 

--- a/src/Polynomials/CartProdPolyBases.jl
+++ b/src/Polynomials/CartProdPolyBases.jl
@@ -39,12 +39,14 @@ struct CartProdPolyBasis{D,V,PT} <: PolynomialBasis{D,V,PT}
     orders::NTuple{D,Int},
     terms::Vector{CartesianIndex{D}}) where {D,V,PT<:Polynomial}
 
+    VV = ifelse(isconcretetype(V),V,typeof(zero(V)))
+    @check isconcretetype(VV) "Trying to build CartProdPolyBasis with non-concrete output type $(VV)"
     @check isconcretetype(PT) "PT needs to be a concrete <:Polynomial type"
 
     K = maximum(orders; init=0)
     msg =  "Some term contain a higher index than the maximum degree + 1."
     @check all( term -> (maximum(Tuple(term), init=0) <= K+1), terms) msg
-    new{D,V,PT}(K,orders,terms)
+    new{D,VV,PT}(K,orders,terms)
   end
 end
 

--- a/src/Polynomials/CartProdPolyBases.jl
+++ b/src/Polynomials/CartProdPolyBases.jl
@@ -39,8 +39,7 @@ struct CartProdPolyBasis{D,V,PT} <: PolynomialBasis{D,V,PT}
     orders::NTuple{D,Int},
     terms::Vector{CartesianIndex{D}}) where {D,V,PT<:Polynomial}
 
-    VV = ifelse(isconcretetype(V),V,typeof(zero(V)))
-    @check isconcretetype(VV) "Trying to build CartProdPolyBasis with non-concrete output type $(VV)"
+    VV = make_concretetype(V)
     @check isconcretetype(PT) "PT needs to be a concrete <:Polynomial type"
 
     K = maximum(orders; init=0)

--- a/src/Polynomials/CompWiseTensorPolyBases.jl
+++ b/src/Polynomials/CompWiseTensorPolyBases.jl
@@ -59,12 +59,15 @@ struct CompWiseTensorPolyBasis{D,V,PT} <: PolynomialBasis{D,V,PT}
     @check size(orders,2) == D msg3
     @check isconcretetype(PT) "PT needs to be a concrete <:Polynomial type"
 
+    VV = ifelse(isconcretetype(V),V,typeof(zero(V)))
+    @check isconcretetype(VV) "Trying to build CompWiseTensorPolyBasis with non-concrete output type $(VV)"
+
     K = maximum(orders)
     num_poly = mapreduce(length, +, comp_terms)
 
     #TODO check orders in `orders` greater or equal than max index in terms
 
-    new{D,V,PT}(num_poly,K,orders,comp_terms)
+    new{D,VV,PT}(num_poly,K,orders,comp_terms)
   end
 end
 

--- a/src/Polynomials/CompWiseTensorPolyBases.jl
+++ b/src/Polynomials/CompWiseTensorPolyBases.jl
@@ -59,9 +59,7 @@ struct CompWiseTensorPolyBasis{D,V,PT} <: PolynomialBasis{D,V,PT}
     @check size(orders,2) == D msg3
     @check isconcretetype(PT) "PT needs to be a concrete <:Polynomial type"
 
-    VV = ifelse(isconcretetype(V),V,typeof(zero(V)))
-    @check isconcretetype(VV) "Trying to build CompWiseTensorPolyBasis with non-concrete output type $(VV)"
-
+    VV = make_concretetype(V)
     K = maximum(orders)
     num_poly = mapreduce(length, +, comp_terms)
 

--- a/src/Polynomials/ModalC0Bases.jl
+++ b/src/Polynomials/ModalC0Bases.jl
@@ -43,8 +43,7 @@ struct ModalC0Basis{D,V,T} <: PolynomialBasis{D,V,ModalC0}
     _msg =  "The number of bounding box points in a and b should match the number of terms"
     @check length(terms) == length(a) == length(b) _msg
     @check T == eltype(V) "Point and polynomial values should have the same scalar body"
-    VV = ifelse(isconcretetype(V),V,typeof(zero(V)))
-    @check isconcretetype(VV) "Trying to build CompWiseTensorPolyBasis with non-concrete output type $(VV)"
+    VV = make_concretetype(V)
     K = maximum(orders, init=0)
 
     new{D,VV,T}(K,orders,terms,a,b)

--- a/src/Polynomials/ModalC0Bases.jl
+++ b/src/Polynomials/ModalC0Bases.jl
@@ -43,9 +43,11 @@ struct ModalC0Basis{D,V,T} <: PolynomialBasis{D,V,ModalC0}
     _msg =  "The number of bounding box points in a and b should match the number of terms"
     @check length(terms) == length(a) == length(b) _msg
     @check T == eltype(V) "Point and polynomial values should have the same scalar body"
+    VV = ifelse(isconcretetype(V),V,typeof(zero(V)))
+    @check isconcretetype(VV) "Trying to build CompWiseTensorPolyBasis with non-concrete output type $(VV)"
     K = maximum(orders, init=0)
 
-    new{D,V,T}(K,orders,terms,a,b)
+    new{D,VV,T}(K,orders,terms,a,b)
   end
 end
 

--- a/src/TensorValues/MultiValueTypes.jl
+++ b/src/TensorValues/MultiValueTypes.jl
@@ -71,6 +71,8 @@ has 6 and a `SymTracelessTensorValue{3}` has 5. But they all have 9 (non indepen
 num_indep_components(::Type{T}) where T<:Number = num_components(T)
 num_indep_components(::T) where T<:Number = num_indep_components(T)
 
+get_indep_components(a::MultiValue) = Tuple(a)
+
 """
 !!! warning
     Deprecated in favor on [`num_components`](@ref).

--- a/src/TensorValues/MultiValueTypes.jl
+++ b/src/TensorValues/MultiValueTypes.jl
@@ -97,6 +97,11 @@ function rand(rng::AbstractRNG,::Random.SamplerType{V}) where V<:MultiValue{D,T}
   V(Tuple(vrand))
 end
 
+function make_concretetype(::Type{T}) where T <: Number
+  TT = ifelse(isconcretetype(T),T,typeof(zero(T)))
+  @check isconcretetype(TT) "Type $(T) cannot be made concrete."
+  return TT
+end
 
 ## ATM it is not possible to implement array like axes because lazy_mapping
 ## operations / broadcast rely on axes(::MultiValue) adopting the Number convention to return ().

--- a/src/TensorValues/Operations.jl
+++ b/src/TensorValues/Operations.jl
@@ -86,14 +86,12 @@ for op in (:+,:-)
   @eval begin
 
     function ($op)(a::T) where T<:MultiValue
-      Li = num_indep_components(T)
-      r = map($op, Tuple(a)[1:Li])
+      r = map($op, get_indep_components(a))
       T(r)
     end
 
     function ($op)(a::V, b::V) where V<:MultiValue
-      Li = num_indep_components(V)
-      r = map(($op), Tuple(a)[1:Li], Tuple(b)[1:Li])
+      r = map(($op), get_indep_components(a), get_indep_components(b))
       V(r)
     end
   end
@@ -134,16 +132,14 @@ end
 for op in (:+,:-,:*)
   @eval begin
     function ($op)(a::MultiValue, b::_Scalar)
-      Li = num_indep_components(a)
-      r = _bc($op, Tuple(a)[1:Li], b)
+      r = _bc($op, get_indep_components(a), b)
       T = _eltype($op, r, a, b)
       M = change_eltype(a, T)
       M(r)
     end
 
     function ($op)(a::_Scalar, b::MultiValue)
-      Li = num_indep_components(b)
-      r = _bc($op, a, Tuple(b)[1:Li])
+      r = _bc($op, a, get_indep_components(b))
       T = _eltype($op, r, a, b)
       M = change_eltype(b, T)
       M(r)
@@ -159,8 +155,7 @@ _err = "This operation is undefined for traceless tensors"
 (-)(::_Scalar, ::_AbstractTracelessTensor) = error(_err)
 
 function (/)(a::MultiValue, b::_Scalar)
-  Li = num_indep_components(a)
-  r = _bc(/, Tuple(a)[1:Li], b)
+  r = _bc(/, get_indep_components(a), b)
   T = _eltype(/, r, a, b)
   P = change_eltype(a, T)
   P(r)

--- a/src/TensorValues/SymTracelessTensorValueTypes.jl
+++ b/src/TensorValues/SymTracelessTensorValueTypes.jl
@@ -141,3 +141,5 @@ change_eltype(::Type{SymTracelessTensorValue{D,T1,L}},::Type{T2}) where {D,T1,T2
 num_indep_components(::Type{<:SymTracelessTensorValue{0}}) = 0
 num_indep_components(::Type{<:SymTracelessTensorValue{D}}) where {D} = D*(D+1)÷2-1
 
+get_indep_components(a::SymTracelessTensorValue) = Base.front(Tuple(a))
+

--- a/src/TensorValues/TensorValues.jl
+++ b/src/TensorValues/TensorValues.jl
@@ -66,6 +66,7 @@ export skew_symmetric_part
 export num_components
 export num_indep_components
 export change_eltype
+export make_concretetype
 export diagonal_tensor
 export ⊙
 export ⊗

--- a/test/PolynomialsTests/BernsteinBasesTests.jl
+++ b/test/PolynomialsTests/BernsteinBasesTests.jl
@@ -345,4 +345,11 @@ Hbx = _Hbx(D,order,x,H,x2λ)
 test_field_array(b,x,bx,≈, grad=Gbx, gradgrad=Hbx)
 test_field_array(b,x1,bx[1,:],≈,grad=Gbx[1,:],gradgrad=Hbx[1,:])
 
+# value_type must be concrete even when user passes a non-concrete tensor type
+for V in (TensorValue{2,2,Float64}, SymTensorValue{2,Float64},
+          SkewSymTensorValue{2,Float64}, SymFourthOrderTensorValue{2,Float64})
+  @test isconcretetype(value_type(BernsteinBasis(Val(2), V, 1)))
+  @test isconcretetype(value_type(BernsteinBasisOnSimplex{2}(V, 1)))
+end
+
 end # module

--- a/test/PolynomialsTests/CompWiseTensorPolyBasesTests.jl
+++ b/test/PolynomialsTests/CompWiseTensorPolyBasesTests.jl
@@ -59,5 +59,10 @@ Gbx = hcat( [ getindex.(bi,1) .* VectorValue(1.,0)⊗V(1.,0) for bi in evaluate(
 
 test_field_array(b,x,bx,≈, grad=Gbx)
 
+# value_type must be concrete even when user passes a non-concrete tensor type
+for V in (TensorValue{2,2,Float64}, SymTensorValue{2,Float64}, SymFourthOrderTensorValue{2,Float64})
+  L = num_indep_components(V)
+  @test isconcretetype(value_type(CompWiseTensorPolyBasis{2}(Monomial, V, ones(Int, L, 2))))
+end
 
 end # module

--- a/test/PolynomialsTests/ModalC0BasesTests.jl
+++ b/test/PolynomialsTests/ModalC0BasesTests.jl
@@ -141,5 +141,10 @@ G = gradient_type(V,x1)
 r = zeros(G, (1,1))
 @test_throws ErrorException Polynomials._set_derivative_mc0!(r,1,s,0,0,V)
 
+# value_type must be concrete even when user passes a non-concrete tensor type
+for V in (TensorValue{2,2,Float64}, SymTensorValue{2,Float64},
+          SkewSymTensorValue{2,Float64}, SymFourthOrderTensorValue{2,Float64})
+  @test isconcretetype(value_type(ModalC0Basis{2}(V, 1)))
+end
 
 end # module

--- a/test/PolynomialsTests/MonomialBasesTests.jl
+++ b/test/PolynomialsTests/MonomialBasesTests.jl
@@ -278,4 +278,10 @@ order = 2
 @test _ph_filter( (1,1) ,order) == true
 @test _ph_filter( (3,1) ,order) == false
 
+# value_type must be concrete even when user passes a non-concrete tensor type
+for V in (TensorValue{2,2,Float64}, SymTensorValue{2,Float64},
+          SkewSymTensorValue{2,Float64}, SymFourthOrderTensorValue{2,Float64})
+  @test isconcretetype(value_type(MonomialBasis{2}(V, (1,1))))
+end
+
 end # module

--- a/test/TensorValuesTests/OperationsTests.jl
+++ b/test/TensorValuesTests/OperationsTests.jl
@@ -1585,4 +1585,51 @@ ref4 = [sum(T3b[i,j,k]*B[i,k] for i in 1:3, k in 1:3) for j in 1:2]
 @test_throws ArgumentError tensor_contraction(VectorValue(1,2), VectorValue(1,2), (3,), (1,))
 @test_throws ArgumentError tensor_contraction(TensorValue{2,2}(1:4...), VectorValue(1,2), (1,1), (1,1))
 
+
+# promote_op
+
+function test_op_promote(T, op, args...)
+  @test Base.promote_op(op, map(typeof, args)...) == T
+end
+
+v  = VectorValue(1, 2, 3)
+t  = TensorValue(1, 2, 3, 4, 5, 6, 7, 8, 9)
+st = SymTensorValue(1, 2, 3, 5, 6, 9)
+qt = SymTracelessTensorValue(1, 2, 3, 5, 6)
+sk = SkewSymTensorValue(1, 2, 3)
+fo = one(SymFourthOrderTensorValue{2, Int})
+
+test_op_promote(typeof(v  * 2),   *, v,  2)
+test_op_promote(typeof(v  * 2.0), *, v,  2.0)
+test_op_promote(typeof(2  * v),   *, 2,  v)
+test_op_promote(typeof(2.0 * v),  *, 2.0, v)
+test_op_promote(typeof(t  * 2),   *, t,  2)
+test_op_promote(typeof(t  * 2.0), *, t,  2.0)
+test_op_promote(typeof(st * 2),   *, st, 2)
+test_op_promote(typeof(st * 2.0), *, st, 2.0)
+test_op_promote(typeof(qt * 2),   *, qt, 2)
+test_op_promote(typeof(qt * 2.0), *, qt, 2.0)
+test_op_promote(typeof(sk * 2),   *, sk, 2)
+test_op_promote(typeof(sk * 2.0), *, sk, 2.0)
+test_op_promote(typeof(fo * 2),   *, fo, 2)
+test_op_promote(typeof(fo * 2.0), *, fo, 2.0)
+
+test_op_promote(typeof(v  / 2.0), /, v,  2.0)
+test_op_promote(typeof(t  / 2.0), /, t,  2.0)
+test_op_promote(typeof(st / 2.0), /, st, 2.0)
+test_op_promote(typeof(qt / 2.0), /, qt, 2.0)
+test_op_promote(typeof(sk / 2.0), /, sk, 2.0)
+test_op_promote(typeof(fo / 2.0), /, fo, 2.0)
+
+test_op_promote(typeof(v  ⊗ 2),   ⊗, v,  2)
+test_op_promote(typeof(v  ⊗ 2.0), ⊗, v,  2.0)
+test_op_promote(typeof(st ⊗ 2.0), ⊗, st, 2.0)
+test_op_promote(typeof(qt ⊗ 2.0), ⊗, qt, 2.0)
+test_op_promote(typeof(sk ⊗ 2.0), ⊗, sk, 2.0)
+
+test_op_promote(typeof(v  ⊗ v),  ⊗, v,  v)
+test_op_promote(typeof(v  ⊗ st), ⊗, v,  st)
+test_op_promote(typeof(st ⊗ st), ⊗, st, st)
+test_op_promote(typeof(qt ⊗ qt), ⊗, qt, qt)
+
 end # module OperationsTests


### PR DESCRIPTION
The issue here is that `TensorValue{2,2,Float64}` is actually abstract, the concrete version of it being `TensorValue{2,2,Float64,4}`. Although the fourth parameter is completely deterministic, Julia does not allow us to define things like `struct TensorValue{D1,D2,T} <: MultiValue{D1,D2,T,D1*D2}`, which would be ideal. Obviously, the user would always like to use the abstract type, but because the bases construction were just taking whatever type the user provided we ended up with abstract types being used for computations. This is horrible for performance. 

To fix this, I have gone through the code and added a way to actually make the user-given types concrete if possible. @Antoinemarteau let me know if you think there is a better way. 

Needs to be merged after #1293 . 