### PR TITLE
Minor tensor operation tweaks, removed Meta.parse

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Added
+
+- Added type-stable methods to `tensor_contraction` and `Base.permutedims(::MultiValue, perm)`: pass the arguments by `Val`. Since PR[#1301](https://github.com/gridap/Gridap.jl/pull/1301).
+
 ## [0.20.6] - 2026-05-05
 
 ### Added
@@ -64,7 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Minor changesto incorporate the changes in Gridap 0.20, specifically the pullback machinery, into GridapDistributed. Since PR[#1258](https://github.com/gridap/Gridap.jl/pull/1258).
+- Minor changes to incorporate the changes in Gridap 0.20, specifically the pullback machinery, into GridapDistributed. Since PR[#1258](https://github.com/gridap/Gridap.jl/pull/1258).
 
 ## [0.20.0] - 2026-03-18
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,12 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-<<<<<<< HEAD
-
 ### Added
 
 - Added type-stable methods to `tensor_contraction` and `Base.permutedims(::MultiValue, perm)`: pass the arguments by `Val`. Since PR[#1301](https://github.com/gridap/Gridap.jl/pull/1301).
-=======
+
 ## [0.20.7] - 2026-05-12
 
 ### Added
@@ -22,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Minor generalisation of `return_value` for `LinearCombinationMap`. Since PR[#1298](https://github.com/gridap/Gridap.jl/pull/1298).
->>>>>>> 6bafc0b717bcf83aca1ba876e816a7e8a17b6e0d
 
 ## [0.20.6] - 2026-05-05
 

--- a/src/Adaptivity/UniformRefinement.jl
+++ b/src/Adaptivity/UniformRefinement.jl
@@ -279,23 +279,23 @@ end
 end
 
 @generated function _create_cartesian_f2c_maps(nC::NTuple{N,T},ref::NTuple{N,T}) where {N,T}
-  J_f2c   = Meta.parse(prod(["(",["1+(I[$k]-1)÷ref[$k]," for k in 1:N]...,")"]))
-  J_child = Meta.parse(prod(["(",["1+(I[$k]-1)%ref[$k]," for k in 1:N]...,")"]))
+  J_f2c   = [:( 1+(I[$k]-1)÷ref[$k] ) for k in 1:N]
+  J_child = [:( 1+(I[$k]-1)%ref[$k] ) for k in 1:N]
 
-  return :(begin
+  quote
     nF = nC .* ref
     f2c_map   = Vector{Int}(undef,prod(nF))
     child_map = Vector{Int}(undef,prod(nF))
 
     for (i,I) in enumerate(CartesianIndices(nF))
-      J_f2c   = $J_f2c
-      J_child = $J_child
+      J_f2c   = tuple($(J_f2c...))
+      J_child = tuple($(J_child...))
       f2c_map[i] = _c2v(J_f2c,nC)
       child_map[i] = _c2v(J_child,ref)
     end
 
     return f2c_map, child_map
-  end)
+  end
 end
 
 # Return the local indices of the fine points within each face.

--- a/src/Fields/AffineMaps.jl
+++ b/src/Fields/AffineMaps.jl
@@ -90,16 +90,15 @@ function _permdims_for_∇∇(a::MultiValue{Tuple{D1,D2}}) where {D1,D2}
   a
 end
 @generated function _permdims_for_∇∇(a::MultiValue{Tuple{D1,D2,D3}}) where {D1,D2,D3}
-  ss = String[]
+  comps = Expr[]
   for k in 1:D2
     for j in 1:D3
       for i in 1:D1
-        push!(ss,"a[$i,$k,$j],")
+        push!(comps, :(a[$i,$k,$j]))
       end
     end
   end
-  str =  join(ss)
-  Meta.parse("ThirdOrderTensorValue{$D1,$D3,$D2}($str)")
+  :(return ThirdOrderTensorValue{$D1,$D3,$D2}($(Expr(:tuple, comps...))))
 end
 
 function lazy_map(

--- a/src/Polynomials/BernsteinBases.jl
+++ b/src/Polynomials/BernsteinBases.jl
@@ -898,6 +898,6 @@ end
 # @generated function multinoms(::Val{K},::Val{D}) where {K,D}
 #   terms = bernstein_terms(K,D)
 #   multinomials = tuple( (multinomial(α...) for α in terms)... )
-#   Meta.parse("return $multinomials")
+#   :( return $multinomials )
 # end
 #

--- a/src/Polynomials/ModalC0Bases.jl
+++ b/src/Polynomials/ModalC0Bases.jl
@@ -299,31 +299,29 @@ end
   # Git blame me for readable non-generated version
   @notimplementedif num_indep_components(V) != num_components(V) "Not implemented for symmetric Jacobian or Hessian"
 
-  m = Array{String}(undef, size(G))
+  m = Array{Symbol}(undef, size(G))
   N_val_dims = length(size(V))
   s_size = size(G)[1:end-N_val_dims]
 
-  body = "T = eltype(s); z = zero(T);"
+  ex = Expr[]
+  ex = push!(ex, :(T = eltype(s); z = zero(T);) )
+
+  s_syms = [Symbol(:s, Tuple(ci)...) for ci in CartesianIndices(s_size)]
   for ci in CartesianIndices(s_size)
-    id = join(Tuple(ci))
-    body *= "@inbounds s$id = s[$ci];"
+    push!(ex, :(@inbounds $(s_syms[ci]) = s[$ci]))
   end
 
-  V_size = size(V)
-  for (ij,j) in enumerate(CartesianIndices(V_size))
-    for i in CartesianIndices(m)
-      m[i] = "z"
-    end
+  for (ij,j) in enumerate(CartesianIndices(V))
+    fill!(m, :z)
     for ci in CartesianIndices(s_size)
-      id = join(Tuple(ci))
-      m[ci,j] = "s$id"
+      m[ci,j] = s_syms[ci]
     end
-    body *= "i = k + l*($ij-1);"
-    body *= "@inbounds r[i1,i] = ($(join(tuple(m...), ", ")));"
+    push!(ex, :(i = k + l*($ij-1)))
+    push!(ex, :(@inbounds r[i1,k] = $(Expr(:tuple, m...))))
   end
 
-  body = Meta.parse(string("begin ",body," end"))
-  return Expr(:block, body ,:(return k+1))
+  push!(ex, :(return k))
+  return Expr(:block, ex...)
 end
 
 function _hessian_nd!(

--- a/src/TensorValues/Indexing.jl
+++ b/src/TensorValues/Indexing.jl
@@ -255,8 +255,8 @@ upper-triangular off-diagonal pairs (i,j) with i<j in lexicographic order.
 """
 @generated function to_voigt(a::SymTensorValue{D,T,L}) where {D,T,L}
   pairs = _voigt_pairs(D)
-  str = join(["a[$(p[1]),$(p[2])], " for p in pairs])
-  Meta.parse("VectorValue{$L,T}(($str))")
+  comps = [ :( a[$(p[1]),$(p[2])] ) for p in pairs ]
+  :( return VectorValue{L,T}($(Expr(:tuple, comps...))) )
 end
 
 """
@@ -269,8 +269,8 @@ Decode a Voigt-encoded vector to a symmetric second-order tensor.
   D = (isqrt(1+8*L)-1) ÷ 2
   @assert L == D*(D+1)÷2 "from_voigt: VectorValue length $L is not a valid Voigt vector length"
   inv_map = _voigt_inv(D)
-  str = join(["v[$(inv_map[i,j])], " for i in 1:D for j in i:D])
-  Meta.parse("SymTensorValue{$D,T}(($str))")
+  comps = [ :( v[$(inv_map[i,j])] )  for i in 1:D for j in i:D ]
+  :( return SymTensorValue{$D,T}($(Expr(:tuple, comps...))) )
 end
 
 """
@@ -284,9 +284,8 @@ The output eltype `S` is `promote_op(*, typeof(√2), T)`.
 @generated function to_mandel(a::SymTensorValue{D,T,L}) where {D,T,L}
   S = _mandel_eltype(T)
   pairs = _voigt_pairs(D)
-  terms = [i==j ? "convert($S, a[$i,$j])" : "sqrt($S(2)) * a[$i,$j]" for (i,j) in pairs]
-  str = join(terms, ", ")
-  Meta.parse("VectorValue{$L,$S}(($str,))")
+  comps = [ i==j ? :(convert($S, a[$i,$j])) : :(sqrt($S(2)) * a[$i,$j]) for (i,j) in pairs]
+  :( return VectorValue{L,$S}($(Expr(:tuple, comps...))) )
 end
 
 """
@@ -300,9 +299,8 @@ Decode a Mandel-encoded vector to a symmetric second-order tensor.
   @assert L == D*(D+1)÷2 "from_mandel: VectorValue length $L is not a valid Mandel vector length"
   S = _mandel_eltype(T)
   inv_map = _voigt_inv(D)
-  terms = [i==j ? "convert($S, v[$(inv_map[i,j])])" : "v[$(inv_map[i,j])] / sqrt($S(2))" for i in 1:D for j in i:D]
-  str = join(terms, ", ")
-  Meta.parse("SymTensorValue{$D,$S}(($str,))")
+  comps = [ i==j ? :(convert($S, v[$(inv_map[i,j])])) : :(v[$(inv_map[i,j])] / sqrt($S(2)))  for i in 1:D for j in i:D ]
+  :( return SymTensorValue{$D,$S}($(Expr(:tuple, comps...))) )
 end
 
 """
@@ -315,13 +313,12 @@ where M = D(D+1)/2. Entry [I,J] of the result equals `a[i,j,k,l]`, where
 @generated function to_voigt(a::SymFourthOrderTensorValue{D,T,L}) where {D,T,L}
   M = D*(D+1)÷2
   pairs = _voigt_pairs(D)
-  terms = String[]
+  comps = Expr[]
   for J in 1:M, I in 1:M
     i, j = pairs[I]; k, l = pairs[J]
-    push!(terms, "a[$i,$j,$k,$l]")
+    push!(comps, :(a[$i,$j,$k,$l]))
   end
-  str = join(terms, ", ")
-  Meta.parse("TensorValue{$M,$M,T}(($str,))")
+  :( return TensorValue{$M,$M,T}($(Expr(:tuple, comps...))) )
 end
 
 """
@@ -334,13 +331,12 @@ Decode a Voigt matrix to a symmetric fourth-order tensor.
   D = (isqrt(1+8*N)-1) ÷ 2
   @assert N == D*(D+1)÷2 "from_voigt: TensorValue size $N×$N is not a valid Voigt matrix size"
   inv_map = _voigt_inv(D)
-  terms = String[]
+  comps = Expr[]
   for i in 1:D, j in i:D, k in 1:D, l in k:D
     I = inv_map[i,j]; J = inv_map[k,l]
-    push!(terms, "m[$I,$J]")
+    push!(comps, :(m[$I,$J]))
   end
-  str = join(terms, ", ")
-  Meta.parse("SymFourthOrderTensorValue{$D,T}(($str,))")
+  :( return SymFourthOrderTensorValue{$D,T}($(Expr(:tuple, comps...))) )
 end
 
 """
@@ -355,19 +351,18 @@ The output eltype `S` is `promote_op(*, typeof(√2), T)`.
   M = D*(D+1)÷2
   S = _mandel_eltype(T)
   pairs = _voigt_pairs(D)
-  terms = String[]
+  comps = Expr[]
   for J in 1:M, I in 1:M
     i, j = pairs[I]; k, l = pairs[J]
     if i==j && k==l
-      push!(terms, "convert($S, a[$i,$j,$k,$l])")
+      push!(comps, :(convert($S, a[$i,$j,$k,$l])))
     elseif i==j || k==l
-      push!(terms, "sqrt($S(2)) * a[$i,$j,$k,$l]")
+      push!(comps, :(sqrt($S(2)) * a[$i,$j,$k,$l]))
     else
-      push!(terms, "$S(2) * a[$i,$j,$k,$l]")
+      push!(comps, :($S(2) * a[$i,$j,$k,$l]))
     end
   end
-  str = join(terms, ", ")
-  Meta.parse("TensorValue{$M,$M,$S}(($str,))")
+  :( return TensorValue{$M,$M,$S}($(Expr(:tuple, comps...))) )
 end
 
 """
@@ -381,18 +376,17 @@ Decode a Mandel matrix to a symmetric fourth-order tensor.
   @assert N == D*(D+1)÷2 "from_mandel: TensorValue size $N×$N is not a valid Mandel matrix size"
   S = _mandel_eltype(T)
   inv_map = _voigt_inv(D)
-  terms = String[]
+  comps = Expr[]
   for i in 1:D, j in i:D, k in 1:D, l in k:D
     I = inv_map[i,j]; J = inv_map[k,l]
     if i==j && k==l
-      push!(terms, "convert($S, m[$I,$J])")
+      push!(comps, :(convert($S, m[$I,$J])))
     elseif i==j || k==l
-      push!(terms, "m[$I,$J] / sqrt($S(2))")
+      push!(comps, :(m[$I,$J] / sqrt($S(2))))
     else
-      push!(terms, "m[$I,$J] / $S(2)")
+      push!(comps, :(m[$I,$J] / $S(2)))
     end
   end
-  str = join(terms, ", ")
-  Meta.parse("SymFourthOrderTensorValue{$D,$S}(($str,))")
+  :( return SymFourthOrderTensorValue{$D,$S}($(Expr(:tuple, comps...))) )
 end
 

--- a/src/TensorValues/Indexing.jl
+++ b/src/TensorValues/Indexing.jl
@@ -256,7 +256,7 @@ upper-triangular off-diagonal pairs (i,j) with i<j in lexicographic order.
 @generated function to_voigt(a::SymTensorValue{D,T,L}) where {D,T,L}
   pairs = _voigt_pairs(D)
   comps = [ :( a[$(p[1]),$(p[2])] ) for p in pairs ]
-  :( return VectorValue{L,T}($(Expr(:tuple, comps...))) )
+  :( return VectorValue{L,T}($(comps...)) )
 end
 
 """
@@ -270,7 +270,7 @@ Decode a Voigt-encoded vector to a symmetric second-order tensor.
   @assert L == D*(D+1)÷2 "from_voigt: VectorValue length $L is not a valid Voigt vector length"
   inv_map = _voigt_inv(D)
   comps = [ :( v[$(inv_map[i,j])] )  for i in 1:D for j in i:D ]
-  :( return SymTensorValue{$D,T}($(Expr(:tuple, comps...))) )
+  :( return SymTensorValue{$D,T}($(comps...)) )
 end
 
 """
@@ -285,7 +285,7 @@ The output eltype `S` is `promote_op(*, typeof(√2), T)`.
   S = _mandel_eltype(T)
   pairs = _voigt_pairs(D)
   comps = [ i==j ? :(convert($S, a[$i,$j])) : :(sqrt($S(2)) * a[$i,$j]) for (i,j) in pairs]
-  :( return VectorValue{L,$S}($(Expr(:tuple, comps...))) )
+  :( return VectorValue{L,$S}($(comps...)) )
 end
 
 """
@@ -300,7 +300,7 @@ Decode a Mandel-encoded vector to a symmetric second-order tensor.
   S = _mandel_eltype(T)
   inv_map = _voigt_inv(D)
   comps = [ i==j ? :(convert($S, v[$(inv_map[i,j])])) : :(v[$(inv_map[i,j])] / sqrt($S(2)))  for i in 1:D for j in i:D ]
-  :( return SymTensorValue{$D,$S}($(Expr(:tuple, comps...))) )
+  :( return SymTensorValue{$D,$S}($(comps...)) )
 end
 
 """
@@ -318,7 +318,7 @@ where M = D(D+1)/2. Entry [I,J] of the result equals `a[i,j,k,l]`, where
     i, j = pairs[I]; k, l = pairs[J]
     push!(comps, :(a[$i,$j,$k,$l]))
   end
-  :( return TensorValue{$M,$M,T}($(Expr(:tuple, comps...))) )
+  :( return TensorValue{$M,$M,T}($(comps...)) )
 end
 
 """
@@ -336,7 +336,7 @@ Decode a Voigt matrix to a symmetric fourth-order tensor.
     I = inv_map[i,j]; J = inv_map[k,l]
     push!(comps, :(m[$I,$J]))
   end
-  :( return SymFourthOrderTensorValue{$D,T}($(Expr(:tuple, comps...))) )
+  :( return SymFourthOrderTensorValue{$D,T}($(comps...)) )
 end
 
 """
@@ -362,7 +362,7 @@ The output eltype `S` is `promote_op(*, typeof(√2), T)`.
       push!(comps, :($S(2) * a[$i,$j,$k,$l]))
     end
   end
-  :( return TensorValue{$M,$M,$S}($(Expr(:tuple, comps...))) )
+  :( return TensorValue{$M,$M,$S}($(comps...)) )
 end
 
 """
@@ -387,6 +387,6 @@ Decode a Mandel matrix to a symmetric fourth-order tensor.
       push!(comps, :(m[$I,$J] / $S(2)))
     end
   end
-  :( return SymFourthOrderTensorValue{$D,$S}($(Expr(:tuple, comps...))) )
+  :( return SymFourthOrderTensorValue{$D,$S}($(comps...)) )
 end
 

--- a/src/TensorValues/Operations.jl
+++ b/src/TensorValues/Operations.jl
@@ -112,21 +112,19 @@ end
 ###############################################################
 
 @generated function _bc(f, a::NTuple{N}, b::Number) where N
-  s = "("
+  res = Expr(:tuple)
   for i in 1:N
-    s *= "f(a[$i],b), "
+    push!(res.args, :(f(a[$i],b)) )
   end
-  s *= ")"
-  Meta.parse(s)
+  res
 end
 
 @generated function _bc(f, b::Number, a::NTuple{N}) where N
-  s = "("
+  res = Expr(:tuple)
   for i in 1:N
-    s *= "f(b,a[$i]), "
+    push!(res.args, :(f(b,a[$i])) )
   end
-  s *= ")"
-  Meta.parse(s)
+  res
 end
 
 for op in (:+,:-,:*)
@@ -232,18 +230,18 @@ inner(a::MultiValue{S,Ta,N}, b::MultiValue{S,Tb,N}) where {S,Ta,Tb,N} = contract
 
 @generated function inner(a::AbstractSymTensorValue{D,Ta}, b::AbstractSymTensorValue{D,Tb}) where {D,Ta,Tb}
   iszero(D) && return :(zero($(Base.promote_op(*,Ta,Tb))))
-  str = ""
+  terms = Expr(:call, :+)
   for i in 1:D
-    str *= "+ a[$i,$i]*b[$i,$i]"
+    push!(terms.args, :(a[$i,$i]*b[$i,$i]))
   end
-  str *= " + 2*("
+  terms2 = Expr(:call, :+)
   for i in 1:D
     for j in i+1:D
-      str *= "+ a[$i,$j]*b[$i,$j]"
+      push!(terms2.args, :(a[$i,$j]*b[$i,$j]))
     end
   end
-  str *= ")"
-  Meta.parse(str)
+  push!(terms.args, :(2*( $terms2 )))
+  terms
 end
 
 @generated function inner(a::SymFourthOrderTensorValue{D,Ta}, b::SymFourthOrderTensorValue{D,Tb}) where {D,Ta,Tb}
@@ -251,18 +249,18 @@ end
 
   S = Tuple{D,D,D,D}
   VInt = change_eltype(a, Int)
-  # each independent component appear either 1,2 of 4 times in inputs
-  strs = Dict(1 => "(", 2 => "2*(", 4 => "4*(")
+  # each independent component appear either 1,2 of 4 times in inputs, we gather
+  # sums for all cases in different expr.
+  sums = [ Expr(:call, :+) for _ in 1:4 ] # the third is unused...
 
   # for each independent component, add its product in the sum of the
   # corresponding multiplicative factor
   for (i, fi) in enumerate(component_basis(VInt))
     factor = @invoke inner(fi::MultiValue{S,Int,4}, fi::MultiValue{S,Int,4}) # use the generic but slower method
-    strs[factor] *= "+ indep_comp_getindex(a,$i)*indep_comp_getindex(b,$i)"
+    push!(sums[factor].args, :(indep_comp_getindex(a,$i)*indep_comp_getindex(b,$i)))
   end
 
-  str = string(strs[1][:], ") + ", strs[2][:], ") + ", strs[4][:], ")")
-  Meta.parse(str)
+  :( $(sums[1]) + 2*$(sums[2]) + 4*$(sums[4]) )
 end
 
 function inner(a::SkewSymTensorValue{D,Ta}, b::SkewSymTensorValue{D,Tb}) where {D,Ta,Tb}
@@ -312,17 +310,17 @@ double_contraction(a::MultiValue, b::MultiValue) = contracted_product(Val(2), a,
   Sym4TensorIndexing = [1111, 1121, 1131, 1122, 1132, 1133, 2111, 2121, 2131, 2122, 2132, 2133,
     3111, 3121, 3131, 3122, 3132, 3133, 2211, 2221, 2231, 2222, 2232, 2233,
     2311, 2321, 2331, 2322, 2332, 2333, 3311, 3321, 3331, 3322, 3332, 3333]
-  ss = String[]
+  comps = Expr[]
   for off_index in Sym4TensorIndexing
     i = parse(Int, string(off_index)[1])
     j = parse(Int, string(off_index)[2])
     k = parse(Int, string(off_index)[3])
     l = parse(Int, string(off_index)[4])
-    s = join(["a[$j,$i,$m,$n]*b[$m,$n,$l,$k]+" for m in 1:3 for n in 1:3])
-    push!(ss, s[1:(end-1)] * ", ")
+    summands = [:( a[$j,$i,$m,$n]*b[$m,$n,$l,$k] ) for m in 1:3 for n in 1:3]
+    comp = Expr(:call, :+, summands...)
+    push!(comps, comp)
   end
-  str = join(ss)
-  Meta.parse("SymFourthOrderTensorValue{3}($str)")
+  :( SymFourthOrderTensorValue{3}($(comps...)) )
 end
 
 function _comp_prod_double_symfourth4(::Val{D},a,b,i,j,k,l) where D
@@ -339,19 +337,19 @@ end
 @generated function double_contraction(a::SymFourthOrderTensorValue{D,Ta}, b::SymFourthOrderTensorValue{D,Tb}) where {D,Ta,Tb}
   iszero(D) && return :(SymFourthOrderTensorValue{0,$(Base.promote_op(*,Ta,Tb))}())
 
-  str = ""
+  comps = Expr[]
   for j in 1:D
     for i in j:D
       for l in 1:D
         for k in l:D
           if D < 4
-            s = ""
+            comp = Expr(:call, :+)
             for m in 1:D
               for n in 1:D
-                s *= " a[$i,$j,$m,$n]*b[$m,$n,$k,$l] +"
+                push!(comp.args, :(a[$i,$j,$m,$n]*b[$m,$n,$k,$l]) )
               end
             end
-            str *= s[1:(end-1)] * ", "
+            push!(comps, comp)
           else
             # for D=4, this compiles in <0.05 s, while the other takes 200 s (Julia 1.12).
             # But runtime is 5 times slower 1.6 μs, vs 300 ns
@@ -362,71 +360,65 @@ end
             # This means that the acceleration we get by removing the function
             # likely comes from llvm optimization that recycle partial results
             # of the products for different i,j,k,l
-            str *= "_comp_prod_double_symfourth4(Val(D),a,b,$i,$j,$k,$l), "
+            push!(comps, :(_comp_prod_double_symfourth4(Val(D),a,b,$i,$j,$k,$l)) )
           end
         end
       end
     end
   end
-  Meta.parse("SymFourthOrderTensorValue{D}($str)")
+  :( SymFourthOrderTensorValue{D}($(comps...)) )
 end
 
 # c_ijk = a_ilm*b_lmjk
 @generated function double_contraction(a::ThirdOrderTensorValue{D1,D,D,Ta}, b::SymFourthOrderTensorValue{D,Tb}) where {D1,D,Ta,Tb}
   iszero(length(a)) && return :(zero(ThirdOrderTensorValue{D1,D,D,$(Base.promote_op(*,Ta,Tb))}))
-  ss = String[]
+  comps = Expr[]
   for k in 1:D
     for j in 1:D
       for i in 1:D1
-        s = join(["a[$i,$l,$m]*b[$l,$m,$j,$k]+" for l in 1:D for m in 1:D])
-        push!(ss, s[1:(end-1)] * ", ")
+        summands = [:(a[$i,$l,$m]*b[$l,$m,$j,$k]) for l in 1:D for m in 1:D]
+        push!(comps, Expr(:call, :+, summands...))
       end
     end
   end
-  str = join(ss)
-  Meta.parse("ThirdOrderTensorValue{$D1,$D,$D}($str)")
+  :( ThirdOrderTensorValue{D1,D,D}($(comps...)) )
 end
 
 # c_ij = a_ijkl*b_kl
 @generated function double_contraction(a::SymFourthOrderTensorValue{D,Ta}, b::AbstractSymTensorValue{D,Tb}) where {D,Ta,Tb}
   iszero(D) && return :(zero(SymTensorValue{D,$(Base.promote_op(*,Ta,Tb))}))
-  str = ""
+  comps = Expr[]
   for i in 1:D
     for j in i:D
-      for k in 1:D
-        str *= "+ a[$i,$j,$k,$k]*b[$k,$k]"
-      end
-      str *= " + 2*("
-      for k in 1:D
-        for l in k+1:D
-          str *= "+ a[$i,$j,$k,$l]*b[$k,$l]"
-        end
-      end
-      str *= "), "
+      summands = [:(a[$i,$j,$k,$k]*b[$k,$k]) for k in 1:D]
+      diag_sum = Expr(:call, :+, summands...)
+
+      summands = [:(a[$i,$j,$k,$l]*b[$k,$l]) for k in 1:D for l in k+1:D]
+      offdiag_sum = Expr(:call, :+, summands...)
+
+      push!(comps, :( $diag_sum + 2*$offdiag_sum) )
     end
   end
-  Meta.parse("SymTensorValue{D}($str)")
+  :( SymTensorValue{D}($(comps...)) )
 end
 
 # c_ij = a_kl*b_klij
 @generated function double_contraction(a::AbstractSymTensorValue{D,Ta}, b::SymFourthOrderTensorValue{D,Tb}) where {D,Ta,Tb}
   iszero(D) && return :(zero(SymTensorValue{D,$(Base.promote_op(*,Ta,Tb))}))
-  str = ""
+  comps = Expr[]
   for i in 1:D
     for j in i:D
-      for k in 1:D
-        str *= "+ a[$k,$k]*b[$k,$k,$i,$j]"
-      end
-      str *= " + 2*("
-      for k in 1:D
-        for l in k+1:D
-          str *= "+ a[$k,$l]*b[$k,$l,$i,$j]"
-        end
-      end
-      str *= "), "
+      summands = [:(a[$k,$k]*b[$k,$k,$i,$j]) for k in 1:D]
+      diag_sum = Expr(:call, :+, summands...)
+
+      summands = [:(a[$k,$l]*b[$k,$l,$i,$j]) for k in 1:D for l in k+1:D]
+      offdiag_sum = Expr(:call, :+, summands...)
+
+      push!(comps, :( $diag_sum + 2*$offdiag_sum) )
     end
   end
-  Meta.parse("SymTensorValue{D}($str)")
+
+  :( SymTensorValue{D}($(comps...)) )
 end
 
 # c_ij = a_ijkl*b_kl
@@ -501,17 +493,17 @@ outer(a::MultiValue, b::MultiValue) = contracted_product(Val(0), a, b)
 # c_ijkl = a_ij*b_kl
 @generated function outer(a::AbstractSymTensorValue{D,Ta}, b::AbstractSymTensorValue{D,Tb}) where {D,Ta,Tb}
   iszero(D) && return :(zero(SymFourthOrderTensorValue{D,$(Base.promote_op(*,Ta,Tb))}))
-  str = ""
+  comps = Expr[]
   for i in 1:D
     for j in i:D
       for k in 1:D
         for l in k:D
-          str *= "a[$i,$j]*b[$k,$l], "
+          push!(comps, :(a[$i,$j]*b[$k,$l]) )
         end
       end
     end
   end
-  Meta.parse("SymFourthOrderTensorValue{D}($str)")
+  :( SymFourthOrderTensorValue{D}($(comps...)) )
 end
 
 const ⊗ = outer
@@ -568,21 +560,21 @@ the specific functions above if possible), but is used as default generic implem
 
   Sr = tuple(Sa_keep..., Sb_keep...)
   Nr = length(Sr)
-  Vstr = if Nr == 0
-    ""
+  V = if Nr == 0
+    :()
   elseif Nr == 1
-    "VectorValue{$(Sr[1])}"
+    :( VectorValue{$(Sr[1])} )
   elseif Nr == 2
-    "TensorValue{$(Sr[1]),$(Sr[2])}"
+    :( TensorValue{$(Sr[1]),$(Sr[2])} )
   else
-    "HighOrderTensorValue{$(Tuple{Sr...})}"
+    :( HighOrderTensorValue{$(Tuple{Sr...})} )
   end
 
   if (iszero(length(a)) || iszero(length(b)))
     if iszero(Nr)
-      return Meta.parse("zero(Base.promote_op(*,Ta,Tb))")
+      return :( zero(Base.promote_op(*,Ta,Tb)) )
     else
-      return Meta.parse("zero("*Vstr*"{Base.promote_op(*,Ta,Tb)})")
+      return :( zero($V{Base.promote_op(*,Ta,Tb)}) )
     end
   end
 
@@ -590,16 +582,14 @@ the specific functions above if possible), but is used as default generic implem
   # to runtime looping over the indices, or even using BLAS. Also, we might need
   # to change HighOrderTensorValue to store into Memory or simply some fixed sized array.
   # Context: compiling double_contaction of 4th order 4D tensors takes 5-10 min, runtime 15μs.
-  ss = String[Vstr, "("]
+  comps = Expr[]
   for cib in CartesianIndices(Sb_keep) # Julia is column major, last index enumerates first
     for cia in CartesianIndices(Sa_keep)
-      push!(ss, join("+a[$cia, $ciC]*b[$ciC, $cib]" for ciC in CartesianIndices(S_contract)))
-      push!(ss, ", ")
+      summands = [:(a[$cia, $ciC]*b[$ciC, $cib]) for ciC in CartesianIndices(S_contract)]
+      push!(comps, Expr(:call, :+, summands...))
     end
   end
-  pop!(ss) #rm last comma in case of scalar output
-  push!(ss, ")")
-  Meta.parse(join(ss))
+  iszero(Nr) ? :( $(comps[1]) ) : :( $V($(comps...)) )
 end
 
 ###############################################################
@@ -1038,8 +1028,8 @@ Return the trace of a second order square tensor, defined by `Σᵢ vᵢᵢ` or 
 """
 @generated function tr(v::MultiValue{Tuple{D,D},T}) where {D,T}
   iszero(D) && return :(zero(T))
-  str = join([" v[$i,$i] +" for i in 1:D])
-  Meta.parse(str[1:(end-1)])
+  summands = [:(v[$i,$i]) for i in 1:D]
+  Expr(:call, :+, summands...)
 end
 tr(::SymTracelessTensorValue{D,T}) where {D,T} = zero(T)
 tr(::SkewSymTensorValue{D,T}) where {D,T} = zero(T)
@@ -1067,17 +1057,13 @@ Return a vector of length `D2` of traces computed on the first two indices: `res
 
   B = last(S.parameters)
   iszero(length(v)) && return :(zero(VectorValue{$B,T}))
-  str = ""
+
+  comps = Expr[]
   for k in 1:B
-    for i in 1:A12[1]
-      if i != 1
-        str *= " + "
-      end
-      str *= " v[$i,$i,$k]"
-    end
-    str *= ", "
+    summands = [:( v[$i,$i,$k] ) for i in 1:A12[1]]
+    push!(comps, Expr(:call, :+, summands...))
   end
-  Meta.parse("VectorValue($str)")
+  :( VectorValue($(comps...)) )
 end
 
 ###############################################################
@@ -1088,23 +1074,23 @@ adjoint(a::MultiValue{Tuple{D,D}}) where D = @notimplemented
 transpose(a::MultiValue{Tuple{D,D}}) where D = @notimplemented
 
 @generated function adjoint(a::TensorValue{D1,D2,T}) where {D1,D2,T}
-  str = ""
+  comps = Expr[]
   for i in 1:D1
     for j in 1:D2
-      str *= "conj(a[$i,$j]), "
+      push!(comps, :(conj(a[$i,$j])) )
     end
   end
-  Meta.parse("TensorValue{D2,D1,T}($str)")
+  :( TensorValue{D2,D1,T}($(comps...)) )
 end
 
 @generated function transpose(a::TensorValue{D1,D2,T}) where {D1,D2,T}
-  str = ""
+  comps = Expr[]
   for i in 1:D1
     for j in 1:D2
-      str *= "a[$i,$j], "
+      push!(comps, :(a[$i,$j]) )
     end
   end
-  Meta.parse("TensorValue{D2,D1,T}($str)")
+  :( TensorValue{D2,D1,T}($(comps...)) )
 end
 
 @inline function adjoint(a::TensorValue{D1,D2,T}) where {D1,D2,T<:Real}
@@ -1187,14 +1173,13 @@ Return `v` if  `v isa AbstractSymTensorValue`, and the zero symmetric tensor if
 """
 @generated function symmetric_part(v::MultiValue{Tuple{D,D},T}) where {D,T}
   iszero(D) && return :(zero(SymTensorValue{0,T}))
-  str = "("
+  comps = Expr[]
   for j in 1:D
     for i in j:D
-      str *= "(v[$i,$j] + v[$j,$i])/2, "
+      push!(comps, :((v[$i,$j] + v[$j,$i])/2) )
     end
   end
-  str *= ")"
-  Meta.parse("SymTensorValue{D}($str)")
+  :( SymTensorValue{D}($(comps...)) )
 end
 
 symmetric_part(v::AbstractSymTensorValue) = v
@@ -1209,14 +1194,13 @@ Return the zero skew symmetric tensor if `v  isa AbstractSymTensorValue`, and
 """
 @generated function skew_symmetric_part(v::MultiValue{Tuple{D,D},T}) where {D,T}
   iszero(D) && return :(zero(SkewSymTensorValue{0,T}))
-  str = "("
+  comps = Expr[]
   for i in 1:D
     for j in i+1:D
-      str *= "(v[$i,$j] - v[$j,$i])/2, "
+      push!(comps, :((v[$i,$j] - v[$j,$i])/2) )
     end
   end
-  str *= ")"
-  Meta.parse("SkewSymTensorValue{D}($str)")
+  :( SkewSymTensorValue{D}($(comps...)) )
 end
 
 skew_symmetric_part(::AbstractSymTensorValue{D,T}) where {D,T} = zero(SkewSymTensorValue{D,T})

--- a/src/TensorValues/Operations.jl
+++ b/src/TensorValues/Operations.jl
@@ -681,17 +681,21 @@ tensor_contraction(a::MultiValue, b::MultiValue, ia::Int, ib::Int) =
   Nr = length(Sr)
 
   Vstr = if Nr == 0
-    "Base.promote_op(*,Ta,Tb)"
+    ""
   elseif Nr == 1
-    "VectorValue{$(Sr[1]),Base.promote_op(*,Ta,Tb)}"
+    "VectorValue{$(Sr[1])}"
   elseif Nr == 2
-    "TensorValue{$(Sr[1]),$(Sr[2]),Base.promote_op(*,Ta,Tb)}"
+    "TensorValue{$(Sr[1]),$(Sr[2])}"
   else
-    "HighOrderTensorValue{$(Tuple{Sr...}),Base.promote_op(*,Ta,Tb)}"
+    "HighOrderTensorValue{$(Tuple{Sr...})}"
   end
 
   if iszero(length(a)) || iszero(length(b))
-    return Meta.parse("zero($Vstr)")
+    if iszero(Nr)
+      return Meta.parse("zero(Base.promote_op(*,Ta,Tb))")
+    else
+      return Meta.parse("zero("*Vstr*"{Base.promote_op(*,Ta,Tb)})")
+    end
   end
 
   s_a_ranges = ntuple(j -> 1:S_a_kept[j], length(ka))
@@ -719,9 +723,11 @@ tensor_contraction(a::MultiValue, b::MultiValue, ia::Int, ib::Int) =
         end
         push!(terms, "+a[$(join(a_idx,","))]*b[$(join(b_idx,","))]")
       end
-      push!(ss, join(terms) * ", ")
+      push!(ss, join(terms))
+      push!(ss, ", ")
     end
   end
+  pop!(ss) #rm last comma in case of scalar output
   push!(ss, ")")
   Meta.parse(join(ss))
 end

--- a/src/TensorValues/Operations.jl
+++ b/src/TensorValues/Operations.jl
@@ -597,7 +597,9 @@ end
 ###############################################################
 
 """
+    tensor_contraction(a::MultiValue, b::MultiValue, ia::Int, ib::Int)
     tensor_contraction(a::MultiValue, b::MultiValue, ia::NTuple{N,Int}, ib::NTuple{N,Int})
+    tensor_contraction(a::MultiValue, b::MultiValue, ::Val{ia}, ::Val{ib})
 
 Contract `N` index pairs between tensors `a` and `b`: the `ia[k]`-th index of `a`
 is summed against the `ib[k]`-th index of `b`, for `k = 1, …, N`.
@@ -605,6 +607,10 @@ The contracted dimensions must match pairwise.
 
 The output tensor has the remaining (non-contracted) indices of `a` in their
 original order, followed by those of `b` in their original order.
+
+!!! warning
+    The methods accepting `Int`/`Tuple` are not type inferable and they allocate,
+    pass the arguments by `Val` if they are known at compile time.
 
 Generalises [`contracted_product`](@ref): `contracted_product(Val(N), a, b)` is
 equivalent to `tensor_contraction(a, b, (Na-N+1, …, Na), (1, …, N))`.
@@ -614,18 +620,20 @@ function tensor_contraction(
   b::MultiValue{Sb,Tb,Nb},
   ia::NTuple{Nc,Int},
   ib::NTuple{Nc,Int}) where {Sa,Ta,Na,Sb,Tb,Nb,Nc}
-  _tensor_contraction(a, b, Val(ia), Val(ib))
+  tensor_contraction(a, b, Val(ia), Val(ib))
 end
 
 tensor_contraction(a::MultiValue, b::MultiValue, ia::Int, ib::Int) =
   tensor_contraction(a, b, (ia,), (ib,))
 
-@generated function _tensor_contraction(
+@generated function tensor_contraction(
   a::MultiValue{Sa,Ta,Na},
   b::MultiValue{Sb,Tb,Nb},
   ::Val{Ia},
   ::Val{Ib}) where {Sa,Ta,Na,Sb,Tb,Nb,Ia,Ib}
 
+  @assert (Ia isa NTuple || Ia isa Int)
+  @assert (Ib isa NTuple || Ib isa Int)
   @assert (Sa <: Tuple && Sb <: Tuple) "Ill-defined MultiValue"
   Nc = length(Ia)
   @assert length(Ib) == Nc
@@ -670,21 +678,21 @@ tensor_contraction(a::MultiValue, b::MultiValue, ia::Int, ib::Int) =
   Sr = (S_a_kept..., S_b_kept...)
   Nr = length(Sr)
 
-  Vstr = if Nr == 0
-    ""
+  V = if Nr == 0
+    :()
   elseif Nr == 1
-    "VectorValue{$(Sr[1])}"
+    :( VectorValue{$(Sr[1])} )
   elseif Nr == 2
-    "TensorValue{$(Sr[1]),$(Sr[2])}"
+    :( TensorValue{$(Sr[1]),$(Sr[2])} )
   else
-    "HighOrderTensorValue{$(Tuple{Sr...})}"
+    :( HighOrderTensorValue{$(Tuple{Sr...})} )
   end
 
-  if iszero(length(a)) || iszero(length(b))
+  if (iszero(length(a)) || iszero(length(b)))
     if iszero(Nr)
-      return Meta.parse("zero(Base.promote_op(*,Ta,Tb))")
+      return :( zero(Base.promote_op(*,Ta,Tb)) )
     else
-      return Meta.parse("zero("*Vstr*"{Base.promote_op(*,Ta,Tb)})")
+      return :( zero($V{Base.promote_op(*,Ta,Tb)}) )
     end
   end
 
@@ -692,38 +700,37 @@ tensor_contraction(a::MultiValue, b::MultiValue, ia::Int, ib::Int) =
   s_b_ranges = ntuple(j -> 1:S_b_kept[j], length(kb))
   s_c_ranges = ntuple(k -> 1:S_contract[k], Nc)
 
-  ss = String[Vstr * "("]
+  comps = Expr[]
   for cib in Iterators.product(s_b_ranges...)
     for cia in Iterators.product(s_a_ranges...)
-      terms = String[]
+      summands = Expr[]
       for ciC in Iterators.product(s_c_ranges...)
-        a_idx = Vector{Int}(undef, Na)
+        a_idx = zero(MVector{Na,Int})
         for (j, pos) in enumerate(ka)
           a_idx[pos] = cia[j]
         end
         for (k, pos) in enumerate(Ia)
           a_idx[pos] = ciC[k]
         end
-        b_idx = Vector{Int}(undef, Nb)
+        b_idx = zero(MVector{Nb,Int})
         for (j, pos) in enumerate(kb)
           b_idx[pos] = cib[j]
         end
         for (k, pos) in enumerate(Ib)
           b_idx[pos] = ciC[k]
         end
-        push!(terms, "+a[$(join(a_idx,","))]*b[$(join(b_idx,","))]")
+        push!(summands, :(a[$a_idx...]*b[$b_idx...]) )
       end
-      push!(ss, join(terms))
-      push!(ss, ", ")
+      push!(comps, Expr(:call, :+, summands...))
     end
   end
-  pop!(ss) #rm last comma in case of scalar output
-  push!(ss, ")")
-  Meta.parse(join(ss))
+  iszero(Nr) ? :( $(comps[1]) ) : :( $V($(comps...)) )
 end
 
 """
+    tensor_contraction(a::MultiValue, i::Int, j::Int)
     tensor_contraction(a::MultiValue, i::NTuple{N,Int}, j::NTuple{N,Int})
+    tensor_contraction(a::MultiValue, ::Val{i}, ::Val{j})
 
 Self-contraction of `a`: for each pair `k`, index `i[k]` and index `j[k]` of `a`
 are set equal and summed over. `i` and `j` must be disjoint and the paired
@@ -731,22 +738,28 @@ dimensions must match.
 
 The output has the remaining indices of `a` (those not in `i` or `j`) in their
 original order. `tr(a)` is the special case `tensor_contraction(a, (1,), (2,))`.
+
+!!! warning
+    The methods accepting `Int`/`Tuple` are not type inferable and they allocate,
+    pass the arguments by `Val` if they are known at compile time.
 """
 function tensor_contraction(
   a::MultiValue{Sa,Ta,Na},
   i::NTuple{Nc,Int},
   j::NTuple{Nc,Int}) where {Sa,Ta,Na,Nc}
-  _tensor_contraction(a, Val(i), Val(j))
+  tensor_contraction(a, Val(i), Val(j))
 end
 
 tensor_contraction(a::MultiValue, i::Int, j::Int) =
   tensor_contraction(a, (i,), (j,))
 
-@generated function _tensor_contraction(
+@generated function tensor_contraction(
   a::MultiValue{Sa,Ta,Na},
   ::Val{I},
   ::Val{J}) where {Sa,Ta,Na,I,J}
 
+  @assert (I isa NTuple || I isa Int)
+  @assert (J isa NTuple || J isa Int)
   @assert Sa <: Tuple "Ill-defined MultiValue"
   Nc = length(I)
   @assert length(J) == Nc
@@ -778,30 +791,36 @@ tensor_contraction(a::MultiValue, i::Int, j::Int) =
 
   contracted = Set([I..., J...])
   ka         = tuple(filter(idx -> !(idx in contracted), 1:Na)...)
-  S_keep     = ntuple(m -> Sa.parameters[ka[m]], length(ka))
+  Sr     = ntuple(m -> Sa.parameters[ka[m]], length(ka))
   S_contract = ntuple(k -> Sa.parameters[I[k]], Nc)
-  Nr         = length(S_keep)
+  Nr         = length(Sr)
 
-  Vstr = if Nr == 0
-    "Ta"
+  V = if Nr == 0
+    :()
   elseif Nr == 1
-    "VectorValue{$(S_keep[1]),Ta}"
+    :( VectorValue{$(Sr[1])} )
   elseif Nr == 2
-    "TensorValue{$(S_keep[1]),$(S_keep[2]),Ta}"
+    :( TensorValue{$(Sr[1]),$(Sr[2])} )
   else
-    "HighOrderTensorValue{$(Tuple{S_keep...}),Ta}"
+    :( HighOrderTensorValue{$(Tuple{Sr...})} )
   end
 
-  iszero(length(a)) && return Meta.parse("zero($Vstr)")
+  if iszero(length(a))
+    if iszero(Nr)
+      return :( zero(Base.promote_op(*,Ta,Ta)) )
+    else
+      return :( zero($V{Base.promote_op(*,Ta,Ta)}) )
+    end
+  end
 
-  s_keep_ranges     = ntuple(m -> 1:S_keep[m],     length(ka))
+  s_keep_ranges     = ntuple(m -> 1:Sr[m],     length(ka))
   s_contract_ranges = ntuple(k -> 1:S_contract[k], Nc)
 
-  ss = String[Vstr * "("]
+  comps = Expr[]
   for cia in Iterators.product(s_keep_ranges...)
-    terms = String[]
+    summands = Expr[]
     for ciC in Iterators.product(s_contract_ranges...)
-      a_idx = Vector{Int}(undef, Na)
+      a_idx = zero(MVector{Na,Int})
       for (m, pos) in enumerate(ka)
         a_idx[pos] = cia[m]
       end
@@ -811,12 +830,11 @@ tensor_contraction(a::MultiValue, i::Int, j::Int) =
       for (k, pos) in enumerate(J)
         a_idx[pos] = ciC[k]
       end
-      push!(terms, "+a[$(join(a_idx, ","))]")
+      push!(summands, :(a[$a_idx...]))
     end
-    push!(ss, join(terms) * ", ")
+    push!(comps, Expr(:call, :+, summands...))
   end
-  push!(ss, ")")
-  Meta.parse(join(ss))
+  iszero(Nr) ? :( $(comps[1]) ) : :( $V($(comps...)) )
 end
 
 ###############################################################
@@ -1109,23 +1127,36 @@ transpose(a::SkewSymTensorValue) = -a
 
 """
     permutedims(a::MultiValue{Sa,Ta,Na}, perm::NTuple{Na,Int})
+    permutedims(a::MultiValue{Sa,Ta,Na},     ::Val{perm})
 
 Return a tensor whose indices are those of `a` reordered by `perm`:
 `result[i₁,…,iₙ] = a[i_{σ⁻¹(1)},…,i_{σ⁻¹(n)}]`, where `σ = perm`.
 
+!!! warning
+    The method accepting a `Tuple` is not type inferable and it allocates, pass
+    the `perm` by `Val` if it is known at compile time.
+
 The output shape is `(size(a, perm[1]), …, size(a, perm[N]))`.
 For second-order tensors this is equivalent to `transpose` (with `perm = (2,1)`).
 Symmetry of the input tensor is not preserved in the output type.
+
+```@example
+t = TensorValue{2,3}(1:6...)
+permutedims(t, Val((2,1)) ) # 2.123 ns  (0 allocations: 0 bytes)
+permutedims(t, (2,1))       # 82.367 ns (3 allocations: 160 bytes)
+# -> TensorValue{3, 2, Int64, 6}(1, 3, 5, 2, 4, 6)
+```
 """
 function Base.permutedims(
   a::MultiValue{Sa,Ta,Na},
   perm::NTuple{Na,Int}) where {Sa,Ta,Na}
-  _permutedims(a, Val(perm))
+  permutedims(a, Val(perm))
 end
 
-@generated function _permutedims(
+@generated function Base.permutedims(
   a::MultiValue{Sa,Ta,Na}, ::Val{P}) where {Sa,Ta,Na,P}
 
+  @assert P isa Tuple || P isa Int
   @assert Sa <: Tuple "Ill-defined MultiValue"
 
   sort([P...]) == collect(1:Na) || begin
@@ -1136,28 +1167,27 @@ end
   Sa_params = tuple(Sa.parameters...)
   Sr = ntuple(k -> Sa_params[P[k]], Na)
 
-  Vstr = if Na == 1
-    "VectorValue{$(Sr[1]),Ta}"
+  V = if Na == 1
+    :( VectorValue{$(Sr[1]),Ta} )
   elseif Na == 2
-    "TensorValue{$(Sr[1]),$(Sr[2]),Ta}"
+    :( TensorValue{$(Sr[1]),$(Sr[2]),Ta} )
   else
-    "HighOrderTensorValue{$(Tuple{Sr...}),Ta}"
+    :( HighOrderTensorValue{$(Tuple{Sr...}),Ta} )
   end
 
-  iszero(length(a)) && return Meta.parse("zero($Vstr)")
+  iszero(length(a)) && return :( zero($V) )
 
   inv_perm = zeros(Int, Na)
   for k in 1:Na
     inv_perm[P[k]] = k
   end
 
-  ss = String[Vstr * "("]
+  comps = Expr[]
   for ci in CartesianIndices(Sr)
     a_idx = ntuple(k -> ci[inv_perm[k]], Na)
-    push!(ss, "a[$(join(a_idx, ","))], ")
+    push!(comps, :( a[$a_idx...] ) )
   end
-  push!(ss, ")")
-  Meta.parse(join(ss))
+  :( $V($(comps...)) )
 end
 
 ###############################################################

--- a/src/TensorValues/SkewSymTensorValueTypes.jl
+++ b/src/TensorValues/SkewSymTensorValueTypes.jl
@@ -72,15 +72,17 @@ SkewSymTensorValue{D,T1,L}(data::Number...) where {D,T1,L} = SkewSymTensorValue{
 
 #From Square Matrices
 @generated function _flatten_skewsym(data::AbstractArray,::Val{D}) where D
-  check_e = :( @check ($D,$D) == size(data) )
-  str = ""
+  comps = Expr[]
   for i in 1:D
     for j in i+1:D
-      str *= "data[$i,$j], "
+      push!(comps, :(data[$i,$j]))
     end
   end
-  ret_e = Meta.parse(" return ($str)")
-  Expr(:block, check_e, ret_e)
+
+  quote
+    @check ($D,$D) == size(data)
+    return tuple($(comps...))
+  end
 end
 
 SkewSymTensorValue(data::AbstractMatrix{T}) where {T} = ((D1,D2)=size(data); SkewSymTensorValue{D1}(data))
@@ -93,14 +95,16 @@ SkewSymTensorValue{D,T1,L}(data::AbstractMatrix{T2}) where {D,T1,T2,L} = SkewSym
 ###############################################################
 
 @generated function _SkewSymTensorValue_to_array(arg::SkewSymTensorValue{D,T,L}) where {D,T,L}
-  z = zero(T)
-  str = ""
+  comps = Expr[]
   for j in 1:D
     for i in 1:D
-      str *= "arg[$i,$j], "
+      push!(comps, :(arg[$i,$j]))
     end
   end
-  Meta.parse("SMatrix{D,D,T}(($str))")
+
+  quote
+    return SMatrix{D,D,T}( tuple($(comps...)) )
+  end
 end
 
 # Inverse conversion

--- a/src/TensorValues/SymFourthOrderTensorValueTypes.jl
+++ b/src/TensorValues/SymFourthOrderTensorValueTypes.jl
@@ -89,17 +89,17 @@ SymFourthOrderTensorValue{D,T1,L}(data::AbstractArray{T2}) where {D,T1,T2,L} = S
 ###############################################################
 
 @generated function _SymFourthOrder_to_array(arg::SymFourthOrderTensorValue{D,T,L}) where {D,T,L}
-  str = ""
+  comps = Expr[]
   for l in 1:D
     for k in 1:D
       for j in 1:D
         for i in 1:D
-          str *= "arg[$i,$j,$k,$l], "
+          push!(comps, :(arg[$i,$j,$k,$l]))
         end
       end
     end
   end
-  Meta.parse("SArray{Tuple{D,D,D,D},T}(($str))")
+  :( return SArray{Tuple{D,D,D,D},T}( $(Expr(:tuple, comps...))) )
 end
 
 # Inverse conversion

--- a/src/TensorValues/SymFourthOrderTensorValueTypes.jl
+++ b/src/TensorValues/SymFourthOrderTensorValueTypes.jl
@@ -64,19 +64,21 @@ SymFourthOrderTensorValue{D,T1}(data::Number...) where {D,T1} = SymFourthOrderTe
 
 #From square 4-dim Array
 @generated function _flatten_sym_fourth_order_tensor(data::AbstractArray,::Val{D}) where D
-  check_e = :( @check ($D,$D,$D,$D) == size(data) )
-  str = ""
+  comps = Expr[]
   for i in 1:D
     for j in i:D
       for k in 1:D
         for l in k:D
-          str *= "data[$i,$j,$k,$l],"
+          push!(comps, :(data[$i,$j,$k,$l]) )
         end
       end
     end
   end
-  ret_e = Meta.parse("return ($str)")
-  Expr(:block, check_e, ret_e)
+
+  quote
+    @check ($D,$D,$D,$D) == size(data)
+    return tuple($(comps...))
+  end
 end
 
 SymFourthOrderTensorValue(data::AbstractArray{T}) where {T} = ((D,)=size(data); SymFourthOrderTensorValue{D}(data))
@@ -124,8 +126,11 @@ The scalar type `T2` of the result is `typeof(one(T)/2)`.
 """
 @generated function one(::Type{<:SymFourthOrderTensorValue{D,T}}) where {D,T}
   S = typeof(one(T)/2)
-  str = join(["($i==$k && $j==$l) ?  ( $i==$j ? one($S) :  one($S)/2) : zero($S), " for i in 1:D for j in i:D for k in 1:D for l in k:D])
-  Meta.parse("SymFourthOrderTensorValue{D,$S}(($str))")
+  comps = [
+    :( (($i==$k && $j==$l) ?  ( $i==$j ? one($S) :  one($S)/2) : zero($S)) )
+    for i in 1:D for j in i:D for k in 1:D for l in k:D
+  ]
+  :( SymFourthOrderTensorValue{D,$S}($(comps...)) )
 end
 
 change_eltype(::Type{<:SymFourthOrderTensorValue{D}},::Type{T2}) where {D,T2} = SymFourthOrderTensorValue{D,T2}

--- a/src/TensorValues/SymTensorValueTypes.jl
+++ b/src/TensorValues/SymTensorValueTypes.jl
@@ -78,13 +78,13 @@ SymTensorValue{D,T1,L}(data::Number...) where {D,T1,L} = SymTensorValue{D,T1}(da
 #From Square Matrices
 @generated function _flatten_upper_triangle(data::AbstractArray,::Val{D}) where D
   check_e = :( @check ($D,$D) == size(data) )
-  str = ""
+  comps = Expr[]
   for i in 1:D
     for j in i:D
-      str *= "data[$i,$j], "
+    push!(comps, :(data[$i,$j]))
     end
   end
-  ret_e = Meta.parse(" return ($str)")
+  ret_e = :(return $(Expr(:tuple, comps...)))
   Expr(:block, check_e, ret_e)
 end
 
@@ -98,14 +98,14 @@ SymTensorValue{D,T1,L}(data::AbstractMatrix{T2}) where {D,T1,T2,L} = SymTensorVa
 ###############################################################
 
 @generated function _SymTensorValue_to_array(arg::SymTensorValue{D,T,L}) where {D,T,L}
-  str = ""
+  comps = Expr[]
   for j in 1:D
     for i in 1:D
       p = _2d_sym_tensor_linear_index(D,i,j)
-      str *= "arg.data[$p], "
+      push!(comps, :(arg.data[$p]))
     end
   end
-  Meta.parse("SMatrix{D,D,T}(($str))")
+  :( return SMatrix{D,D,T}( $(Expr(:tuple, comps...))) )
 end
 
 # Inverse conversion
@@ -121,8 +121,8 @@ convert(::Type{<:SymTensorValue{D,T}}, arg::SymTensorValue{D,T}) where {D,T} = a
 ###############################################################
 
 @generated function one(::Type{<:SymTensorValue{D,T}}) where {D,T}
-  str = join(["$i==$j ? one(T) : zero(T), " for i in 1:D for j in i:D])
-  Meta.parse("SymTensorValue{D,T}(($str))")
+  comps = [ i==j ? :(one(T)) : :(zero(T))  for i in 1:D for j in i:D]
+  :( return SymTensorValue{D,T}( $(Expr(:tuple, comps...))) )
 end
 
 change_eltype(::Type{<:SymTensorValue{D}},::Type{T2}) where {D,T2} = SymTensorValue{D,T2}

--- a/src/TensorValues/SymTracelessTensorValueTypes.jl
+++ b/src/TensorValues/SymTracelessTensorValueTypes.jl
@@ -26,12 +26,12 @@ struct SymTracelessTensorValue{D,T,L} <: AbstractSymTensorValue{D,T,L}
 end
 
 @generated function _minus_trace(data::NTuple{L,T},::Val{D}) where {D,T,L}
-  str = ""
+  trace_expr = Expr(:call, :+)
   for i in 1:D-1
     k = _2d_sym_tensor_linear_index(D,i,i)
-    str *= "- data[$k]"
+    push!(trace_expr.args, :(- data[$k]) )
   end
-  Meta.parse("($str)")
+  return trace_expr
 end
 
 const QTensorValue = SymTracelessTensorValue
@@ -93,15 +93,17 @@ SymTracelessTensorValue{D,T1,L}(data::Number...) where {D,T1,L} = SymTracelessTe
 
 #From Square Matrices
 @generated function _flatten_upper_triangle_traceless(data::AbstractArray,::Val{D}) where D
-  check_e = :( @check ($D,$D) == size(data) )
-  str = ""
+  comps = Expr[]
   for i in 1:D-1
     for j in i:D
-      str *= "data[$i,$j], "
+      push!(comps, :( data[$i,$j]))
     end
   end
-  ret_e = Meta.parse(" return ($str)")
-  Expr(:block, check_e, ret_e)
+
+  quote
+    @check ($D,$D) == size(data)
+    return tuple($(comps...))
+  end
 end
 
 SymTracelessTensorValue(data::AbstractMatrix{T}) where {T} = ((D1,D2)=size(data); SymTracelessTensorValue{D1}(data))
@@ -114,13 +116,13 @@ SymTracelessTensorValue{D,T1,L}(data::AbstractMatrix{T2}) where {D,T1,T2,L} = Sy
 ###############################################################
 
 @generated function _SymTracelessTensorValue_to_array(arg::SymTracelessTensorValue{D,T,L}) where {D,T,L}
-  str = ""
+  comps = Expr[]
   for j in 1:D
     for i in 1:D
-      str *= "arg[$i,$j], "
+      push!(comps, :( arg[$i,$j]))
     end
   end
-  Meta.parse("SMatrix{D,D,T}(($str))")
+  :( SMatrix{$D,$D,T}($(comps...)) )
 end
 
 # Inverse conversion

--- a/src/TensorValues/TensorValueTypes.jl
+++ b/src/TensorValues/TensorValueTypes.jl
@@ -93,8 +93,8 @@ MultiValue(a::StaticMatrix{D1,D2,T}) where {D1,D2,T} = convert(TensorValue{D1,D2
 ###############################################################
 
 @generated function one(::Type{<:TensorValue{D1,D2,T}}) where {D1,D2,T}
-  str = join(["$i==$j ? one(T) : zero(T), " for j in 1:D2 for i in 1:D1])
-  Meta.parse("TensorValue{D1,D2,T}(($str))")
+  m = [ (ci[1] == ci[2] ? :( one(T) ) : :(zero(T)) ) for ci in CartesianIndices((D1,D2)) ]
+  :( return TensorValue{D1,D2,T}($(Expr(:tuple, m...))) )
 end
 
 change_eltype(::Type{<:TensorValue{D1,D2}},::Type{T2}) where {D1,D2,T2} = TensorValue{D1,D2,T2}
@@ -106,13 +106,8 @@ change_eltype(::Type{TensorValue{D1,D2,T1,L}},::Type{T2}) where {D1,D2,T1,T2,L} 
 Return a diagonal `D`×`D` tensor with diagonal containing the elements of `v`.
 """
 @generated function diagonal_tensor(v::VectorValue{D,T}) where {D,T}
-  s = ["zero(T), " for i in 1:(D*D)]
-  for i in 1:D
-    d = D*(i-1)+i
-    s[d] = "v.data[$i],"
-  end
-  str = join(s)
-  Meta.parse("TensorValue{D,D,T,$(D*D)}(($str))")
+  m = [ (ci[1] == ci[2] ? :( v[$(ci[1])] ) : :(zero(T)) ) for ci in CartesianIndices((D,D)) ]
+  :( return TensorValue{D,D,T}($(Expr(:tuple, m...))) )
 end
 
 """
@@ -121,13 +116,8 @@ end
 Return a `D1`×`D2` tensor with columns given by the `D1`-dimensional vectors in `cols`.
 """
 @generated function tensor_from_columns(cols::NTuple{D2,VectorValue{D1,T}}) where {D1,D2,T}
-  s = ""
-  for j in 1:D2
-    for i in 1:D1
-      s *= "cols[$j].data[$i],"
-    end
-  end
-  Meta.parse("TensorValue{D1,D2,T,$(D1*D2)}(($s))")
+  m = [ :(cols[ $(ci[2]) ][ $(ci[1]) ]) for ci in CartesianIndices((D1,D2)) ]
+  :( return TensorValue{D1,D2,T}($(Expr(:tuple, m...))) )
 end
 
 tensor_from_columns(cols::VectorValue...) = tensor_from_columns(cols)
@@ -138,13 +128,8 @@ tensor_from_columns(cols::VectorValue...) = tensor_from_columns(cols)
 Return a `D1`×`D2` tensor with rows given by the `D2`-dimensional vectors in `rows`.
 """
 @generated function tensor_from_rows(rows::NTuple{D1,VectorValue{D2,T}}) where {D1,D2,T}
-  s = ""
-  for j in 1:D2
-    for i in 1:D1
-      s *= "rows[$i].data[$j],"
-    end
-  end
-  Meta.parse("TensorValue{D1,D2,T,$(D1*D2)}(($s))")
+  m = [ :(rows[ $(ci[1]) ][ $(ci[2]) ]) for ci in CartesianIndices((D1,D2)) ]
+  :( return TensorValue{D1,D2,T}($(Expr(:tuple, m...))) )
 end
 
 tensor_from_rows(rows::VectorValue...) = tensor_from_rows(rows)

--- a/test/ODEsTests/ODEProblemsTests/TableausTests.jl
+++ b/test/ODEsTests/ODEProblemsTests/TableausTests.jl
@@ -34,7 +34,7 @@ matrix = [
 
 for tableauname in available_tableaus
   ButcherTableau(tableauname)
-  tableau = eval(Meta.parse("ODEs." * string(tableauname) * "()"))
+  tableau = eval(:(ODEs.$tableauname()))
   ButcherTableau(tableau, Float64)
 end
 

--- a/test/TensorValuesTests/OperationsTests.jl
+++ b/test/TensorValuesTests/OperationsTests.jl
@@ -1463,45 +1463,54 @@ t01c = TensorValue{0,1,ComplexF32}()
 
 # permutedims
 
-# permutedims
-
 v = VectorValue(1,2,3)
 @test permutedims(v, (1,)) == v
-@test isa(permutedims(v, (1,)), VectorValue{3,Int})
+@test permutedims(v, Val((1,))) == v
+@test permutedims(v, Val(1)) == v
+@test isa(permutedims(v, Val(1)), VectorValue{3,Int})
 
 A = TensorValue{2,3}(1,2,3,4,5,6)
 @test permutedims(A, (1,2)) == A
+@test permutedims(A, Val((1,2))) == A
 @test isa(permutedims(A, (1,2)), TensorValue{2,3,Int})
-At = permutedims(A, (2,1))
+At = permutedims(A, Val((2,1)))
 @test isa(At, TensorValue{3,2,Int})
 @test At == transpose(A)
 
 S = SymTensorValue{3}(1,2,3,4,5,6)
-@test permutedims(S, (2,1)) == TensorValue{3,3,Int}(get_array(S)')
+@test permutedims(S, Val((2,1))) == TensorValue{3,3,Int}(get_array(S)')
 
 T3 = ThirdOrderTensorValue{2,3,4}(1:24...)
-@test permutedims(T3, (1,2,3)) == HighOrderTensorValue{Tuple{2,3,4},Int,3}(Tuple(get_array(T3)))
+@test permutedims(T3, Val((1,2,3))) == HighOrderTensorValue{Tuple{2,3,4},Int,3}(Tuple(get_array(T3)))
 
-P213 = permutedims(T3, (2,1,3))
+P213 = permutedims(T3, Val((2,1,3)))
 @test isa(P213, HighOrderTensorValue{Tuple{3,2,4},Int,3})
 @test all(P213[j,i,k] == T3[i,j,k] for i in 1:2, j in 1:3, k in 1:4)
 
-P312 = permutedims(T3, (3,1,2))
+P312 = permutedims(T3, Val((3,1,2)))
 @test isa(P312, HighOrderTensorValue{Tuple{4,2,3},Int,3})
 @test all(P312[k,i,j] == T3[i,j,k] for i in 1:2, j in 1:3, k in 1:4)
 
 r1 = tensor_contraction(T3, VectorValue(1,2,3), (2,), (1,))
 r2 = tensor_contraction(P213, VectorValue(1,2,3), (1,), (1,))
 @test r1 == r2
+r3 = tensor_contraction(T3, VectorValue(1,2,3), Val(2), Val(1))
+@test r1 == r3
+r3 = tensor_contraction(T3, VectorValue(1,2,3), Val((2,)), Val((1,)))
+@test r1 == r3
 
 @test_throws ArgumentError permutedims(A, (1,3))
+@test_throws ArgumentError permutedims(A, Val((1,3)))
 @test_throws ArgumentError permutedims(A, (1,1))
+@test_throws ArgumentError permutedims(A, Val((1,1)))
 
 # tensor_contraction (self-contraction)
 
 # trace as special case
 A2 = TensorValue{3,3}(1:9...)
 @test tensor_contraction(A2, (1,), (2,)) == tr(A2)
+@test tensor_contraction(A2, Val((1,)), Val((2,))) == tr(A2)
+@test tensor_contraction(A2, Val(1), Val(2)) == tr(A2)
 @test isa(tensor_contraction(A2, (1,), (2,)), Int)
 
 # non-square matrix: contract unique index pair → scalar
@@ -1510,80 +1519,82 @@ A23 = TensorValue{2,2}(1,2,3,4)
 
 # partial trace of a 4th-order tensor: C[j,l] = Σ_i A[i,j,i,l]
 A4 = HighOrderTensorValue{Tuple{3,2,3,4}}(reshape(1:72, 3,2,3,4))
-C  = tensor_contraction(A4, (1,), (3,))
+C  = tensor_contraction(A4, Val(1), Val(3))
 @test isa(C, TensorValue{2,4,Int})
 @test all(C[j,l] == sum(A4[i,j,i,l] for i in 1:3) for j in 1:2, l in 1:4)
 
 # double self-contraction: scalar
 A4b = HighOrderTensorValue{Tuple{2,3,2,3}}(reshape(1:36, 2,3,2,3))
 s   = tensor_contraction(A4b, (1,2), (3,4))
+s   = tensor_contraction(A4b, Val((1,2)), Val((3,4)))
 @test isa(s, Int)
 @test s == sum(A4b[i,j,i,j] for i in 1:2, j in 1:3)
 
 # consistency: tr(a) == tensor_contraction(a, (1,), (2,))
 st = SymTensorValue{3}(1,2,3,4,5,6)
-@test tensor_contraction(st, (1,), (2,)) == tr(st)
+@test tensor_contraction(st, Val(1), Val(2)) == tr(st)
 
 # integer signatures
 @test tensor_contraction(A2, 1, 2) == tr(A2)
 @test tensor_contraction(A2, VectorValue(1,2,3), 2, 1) == tensor_contraction(A2, VectorValue(1,2,3), (2,), (1,))
 
 # error cases
-@test_throws ArgumentError tensor_contraction(A2, (1,), (1,))          # i∩j ≠ ∅
-@test_throws ArgumentError tensor_contraction(A2, (3,), (1,))          # out of range
-@test_throws DimensionMismatch tensor_contraction(TensorValue{2,3}(1:6...), (1,), (2,))
+@test_throws ArgumentError tensor_contraction(A2, Val(1), Val(1))          # i∩j ≠ ∅
+@test_throws ArgumentError tensor_contraction(A2, Val(3), Val(1))          # out of range
+@test_throws DimensionMismatch tensor_contraction(TensorValue{2,3}(1:6...), Val(1), Val(2))
 
 # tensor_contraction (two tensors)
 
 A = TensorValue{2,3}(1,2,3,4,5,6)
 x = VectorValue(1,2,3)
-r = tensor_contraction(A, x, (2,), (1,))
+r = tensor_contraction(A, x, Val(2), Val(1))
 @test isa(r, VectorValue{2,Int})
 @test r == A⋅x
 
 y = VectorValue(1,2)
-r2 = tensor_contraction(A, y, (1,), (1,))
+r2 = tensor_contraction(A, y, Val(1), Val(1))
 @test isa(r2, VectorValue{3,Int})
 ref = VectorValue(A[1,1]*y[1]+A[2,1]*y[2], A[1,2]*y[1]+A[2,2]*y[2], A[1,3]*y[1]+A[2,3]*y[2])
 @test r2 == ref
 
 u = VectorValue(1,2,3)
 v = VectorValue(4,5,6)
-@test tensor_contraction(u, v, (1,), (1,)) == u⋅v
+@test tensor_contraction(u, v, Val(1), Val(1)) == u⋅v
 
 M = TensorValue{2,3}(1,2,3,4,5,6)
 N = TensorValue{2,3}(6,5,4,3,2,1)
-@test tensor_contraction(M, N, (1,2), (1,2)) == contracted_product(Val(2), M, N)
+@test tensor_contraction(M, N, Val((1,2)), Val((1,2))) == contracted_product(Val(2), M, N)
 
 t1 = TensorValue{2,3}(1,2,3,4,5,6)
 t2 = TensorValue{2,3}(2,3,4,5,6,7)
-@test tensor_contraction(t1, t2, (1,2), (1,2)) == inner(t1,t2)
+@test tensor_contraction(t1, t2, Val((1,2)), Val((1,2))) == inner(t1,t2)
 
 M2 = TensorValue{2,3}(1,2,3,4,5,6)
 N2 = TensorValue{3,2}(6,5,4,3,2,1)
-@test tensor_contraction(M2, N2, (1,2), (2,1)) == sum(M2[i,j]*N2[j,i] for i in 1:2, j in 1:3)
+@test tensor_contraction(M2, N2, Val((1,2)), Val((2,1))) == sum(M2[i,j]*N2[j,i] for i in 1:2, j in 1:3)
 
 a2 = VectorValue(1,2)
 b3 = VectorValue(3,4,5)
 @test tensor_contraction(a2, b3, (), ()) == outer(a2, b3)
+@test tensor_contraction(a2, b3, Val(()), Val(())) == outer(a2, b3)
 
 T3 = ThirdOrderTensorValue{2,3,4}(1:24...)
 w  = VectorValue(1,2,3)
-r3 = tensor_contraction(T3, w, (2,), (1,))
+r3 = tensor_contraction(T3, w, Val(2), Val(1))
 @test isa(r3, TensorValue{2,4,Int})
 ref3 = [sum(T3[i,k,j]*w[k] for k in 1:3) for i in 1:2, j in 1:4]
 @test get_array(r3) == ref3
 
 T3b = ThirdOrderTensorValue{3,2,3}(1:18...)
 B   = TensorValue{3,3}(1:9...)
-r4  = tensor_contraction(T3b, B, (1,3), (1,2))
+r4  = tensor_contraction(T3b, B, Val((1,3)), Val((1,2)))
 @test isa(r4, VectorValue{2,Int})
 ref4 = [sum(T3b[i,j,k]*B[i,k] for i in 1:3, k in 1:3) for j in 1:2]
 @test r4 == VectorValue(ref4...)
 
-@test_throws DimensionMismatch tensor_contraction(VectorValue(1,2), VectorValue(1,2,3), (1,), (1,))
-@test_throws ArgumentError tensor_contraction(VectorValue(1,2), VectorValue(1,2), (3,), (1,))
-@test_throws ArgumentError tensor_contraction(TensorValue{2,2}(1:4...), VectorValue(1,2), (1,1), (1,1))
+@test_throws DimensionMismatch tensor_contraction(VectorValue(1,2), VectorValue(1,2,3), Val(1), Val(1))
+@test_throws ArgumentError tensor_contraction(VectorValue(1,2), VectorValue(1,2), Val(3), Val(1))
+@test_throws ArgumentError tensor_contraction(TensorValue{2,2}(1:4...), VectorValue(1,2), Val((1,1)), Val((1,1)))
 
 
 # promote_op


### PR DESCRIPTION
- cleant our `@generated` functions by building expressions instead of `Meta.parse`d strings
- added type stable methods to `tensor_contraction` and `Base.permutedims(::MultiValue,...)` (by passing indices by Val directly)
- removed last usage of `promote_op` when unnecessary (non zero-length tensors)
