### PR TITLE
Fixed type instability in array_cache for LazyArray

### DIFF
--- a/src/Arrays/LazyArrays.jl
+++ b/src/Arrays/LazyArrays.jl
@@ -128,23 +128,16 @@ IndexStyle(::Type{<:LazyArray{G,T,1} where {G,T}}) = IndexLinear()
 uses_hash(::Type{<:LazyArray}) = Val{true}()
 
 function same_branch(a,b)
-  a === b
+  return a === b
 end
 
 function same_branch(a::Fill,b::Fill)
   typeof(a) != typeof(b) && return false
   size(a) != size(b) && return false
-  a.value == b.value
+  return a.value == b.value
 end
 
-function all_same_branch(a::Tuple,b::Tuple)
-  for i in 1:length(a)
-    if same_branch(a[i],b[i]) == false
-      return false
-    end
-  end
-  true
-end
+all_same_branch(a::Tuple,b::Tuple) = all(map(same_branch,a,b))
 
 function same_branch(a::LazyArray,b::LazyArray)
   typeof(a) != typeof(b) && return false
@@ -155,26 +148,32 @@ end
 function _get_cache(dict,a)
   id = objectid(a)
   if haskey(dict,id)
-    o,c = dict[id]
+    o, c = dict[id]
     return c
   end
-  for item in dict
-    if same_branch(a,second(item)[1])
-      return second(item)[2]
+  for item in values(dict)
+    o, c = item
+    if same_branch(a,o)
+      return c
     end
   end
   return nothing
 end
 
+# We recompute the cache even if we find an existing one, 
+# because otherwise we CANNOT infer the type and we get 
+# a type instability for every subsequent getindex! call.
 function array_cache(dict::Dict,a::LazyArray)
-  cache = _get_cache(dict,a)
-  if cache === nothing
-    _cache = _array_cache!(dict,a)
-    dict[objectid(a)] = (a,_cache)
+  cache = _array_cache!(dict,a)
+  existing = _get_cache(dict,a)
+  T = typeof(cache)
+  if isnothing(existing)
+    dict[objectid(a)] = (a,cache)
+    return cache::T
   else
-    _cache = cache
+    dict[objectid(a)] = (a,existing)
+    return existing::T
   end
-  _cache
 end
 
 # to memoize last access of a lazy array
@@ -190,16 +189,13 @@ end
 
 function _array_cache!(dict::Dict,a::LazyArray)
   @check begin
-    @notimplementedif ! all(map(isconcretetype, map(eltype, a.args)))
-    if !(eltype(a.maps) <: Function)
-      @notimplementedif !isconcretetype(eltype(a.maps))
-    end
-    true
+    all(map(isconcretetype, map(eltype, a.args))) &&
+      (eltype(a.maps) <: Function || isconcretetype(eltype(a.maps)))
   end
   gi = testitem(a.maps)
   fi = map(testitem,a.args)
   cg = array_cache(dict,a.maps)
-  cf = map(fi->array_cache(dict,fi),a.args)
+  cf = map(Base.Fix1(array_cache, dict),a.args)
   cgi = return_cache(gi, fi...)
   index = -1
   #item = evaluate!(cgi,gi,testargs(gi,fi...)...)

--- a/test/ArraysTests/LazyArraysTests.jl
+++ b/test/ArraysTests/LazyArraysTests.jl
@@ -326,4 +326,22 @@ c = a + b
 @test all(lazy_map(test_map,c,k,a,b))
 @test all(lazy_map((x...)->test_map(x...,cmp=≈),c,k,a,b))
 
+# array_cache type stability: compiler must infer a concrete type (not Any)
+# on both the miss path and the hit path (DAG — same node as multiple args).
+let
+  x = [1.0, 2.0, 3.0]
+  y = lazy_map(a -> a .+ 1.0, x)
+
+  # true DAG — y shared as both args; second array_cache(dict,y) is a cache hit
+  res = lazy_map((a,b) -> a .+ b, y, y)
+  rt = only(Base.return_types(array_cache, (Dict{UInt,Any}, typeof(res))))
+  @test rt != Any
+
+  # correctness — DAG sharing preserved: both occurrences of y share the same IndexItemPair
+  dict = Dict{UInt,Any}()
+  c = array_cache(dict, res)
+  cf = c[1][3]   # cache layout: ((cg, cgi, cf), IndexItemPair) → cf is arg caches
+  @test cf[1][2] === cf[2][2]
+end
+
 end # module


### PR DESCRIPTION
I've been tracking this type instability for some time: with the current implementation, we have

```julia
function array_cache(dict::Dict,a::LazyArray)
  cache = _get_cache(dict,a)
  if cache === nothing
    _cache = _array_cache!(dict,a)
    dict[objectid(a)] = (a,_cache)
  else
    _cache = cache
  end
  _cache
end
```

The issue here is that, when we hit the cache and have `!isnothing(cache)`, the only thing the compiler can see is that the cache comes from a `Dict{UInt,Any}` and thus sets the return type to `Any`. 

This is HORRIBLE, since it generates a type instability that hinders the evaluation of every single subsequent call to `getindex!`, since that `Any` typing is baked into the cache. 

After exploring several solutions, I think we should just pay the price of re-computing the caches. We keep the memoization and the memory savings (the recomputed cache gets thrown away), but we are now able to tell the compiler what type it should expect. The final version is: 

```julia
function array_cache(dict::Dict,a::LazyArray)
  cache = _array_cache!(dict,a)
  existing = _get_cache(dict,a)
  T = typeof(cache)
  if isnothing(existing)
    dict[objectid(a)] = (a,cache)
    return cache::T
  else
    dict[objectid(a)] = (a,existing)
    return existing::T
  end
end
```

This is quite delicate, so I would appreciate a review @amartinhuertas @Antoinemarteau 