### PR TITLE
Fixed type instanbility in Cartesian meshes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed bug for Raviart-Thomas on AppendedTriangulations. Since PR[#1302](https://github.com/gridap/Gridap.jl/pull/1302).
+- Fixed type instability in Cartesian mesh constructor. Since PR[#1304](https://github.com/gridap/Gridap.jl/pull/1304).
 
 ## [0.20.7] - 2026-05-12
 

--- a/src/Geometry/CartesianDiscreteModels.jl
+++ b/src/Geometry/CartesianDiscreteModels.jl
@@ -449,7 +449,7 @@ function _generate_cell_to_vertices_from_grid(
 
   nodes = get_cell_node_ids(grid)
   nnodes = num_nodes(grid)
-  num_nodes_x_dir = [p+1 for p in partition]
+  num_nodes_x_dir = map(p -> p+1, partition)
   point_to_isperiodic, slave_point_to_point, slave_point_to_master_point =
     _generate_slave_to_master_point(num_nodes_x_dir,isperiodic, nnodes)
 
@@ -466,15 +466,15 @@ function _generate_cell_to_vertices_from_grid(
   (cell_to_vertices, vertex_to_node, node_to_vertex)
 end
 
-function _generate_slave_to_master_point(num_nodes_x_dir::Vector{Int},
-  isperiodic::NTuple, num_nodes::Int)
-
+function _generate_slave_to_master_point(
+  num_nodes_x_dir::NTuple{N,Int}, isperiodic::NTuple{N,Bool}, num_nodes::Int
+) where N
   periodic_dirs = findall(x->x==true, isperiodic)
-  linear_indices = LinearIndices(Tuple(num_nodes_x_dir))
-  cartesian_indices = CartesianIndices(Tuple(num_nodes_x_dir))
+  linear_indices = LinearIndices(num_nodes_x_dir)
+  cartesian_indices = CartesianIndices(num_nodes_x_dir)
 
   point_to_isperiodic = fill(false,num_nodes)
-  for point in 1:length(point_to_isperiodic)
+  for point in eachindex(point_to_isperiodic)
     ci = Tuple(cartesian_indices[point])
     for dir in periodic_dirs
       if ci[dir] == num_nodes_x_dir[dir]
@@ -486,16 +486,10 @@ function _generate_slave_to_master_point(num_nodes_x_dir::Vector{Int},
   slave_point_to_point = findall(point_to_isperiodic)
   slave_point_to_master_point = Array{Int32,1}(undef,length(slave_point_to_point))
 
-  ijk = zeros(Int,length(isperiodic))
   for (i,point) in enumerate(slave_point_to_point)
-    ijk .= Tuple(cartesian_indices[point])
-    for i in periodic_dirs
-      if ijk[i] == num_nodes_x_dir[i]
-        ijk[i] = 1
-      end
-    end
-    master_point_ijk = CartesianIndex(Tuple(ijk))
-    slave_point_to_master_point[i] = linear_indices[master_point_ijk]
+    ci = Tuple(cartesian_indices[point])
+    ijk = ntuple(d -> (d in periodic_dirs && ci[d] == num_nodes_x_dir[d]) ? 1 : ci[d], Val(N))
+    slave_point_to_master_point[i] = linear_indices[CartesianIndex(ijk)]
   end
 
   point_to_isperiodic, slave_point_to_point, slave_point_to_master_point


### PR DESCRIPTION
## Issue: `_generate_slave_to_master_point` — `Tuple(vector)` loses length (10 sites)

**File:** `src/Geometry/CartesianDiscreteModels.jl:469`

```julia
function _generate_slave_to_master_point(num_nodes_x_dir::Vector{Int},
    isperiodic::NTuple, num_nodes::Int)
    linear_indices  = LinearIndices(Tuple(num_nodes_x_dir))   # Tuple{Vararg{Int}}
    cartesian_indices = CartesianIndices(Tuple(num_nodes_x_dir))
    ...
    ijk = zeros(Int, length(isperiodic))  # Vector{Int}, length unknown
```

`num_nodes_x_dir::Vector{Int}` has unknown length at compile time, so
`Tuple(num_nodes_x_dir)` produces `Tuple{Vararg{Int64}}` — an unlengthed
tuple type. This makes `CartesianIndices` and `LinearIndices` have unknown
dimensionality, propagating abstract types through all 10 downstream accesses.

Similarly, `isperiodic::NTuple` has no length parameter, so `length(isperiodic)`
is `Int` but `zeros(Int, length(isperiodic))` creates a `Vector{Int}` which
cannot carry the tuple dimension through.

**Root cause:** Function takes `Vector{Int}` instead of an `NTuple{N,Int}` for
`num_nodes_x_dir`, discarding the dimension at the type level.