### PR TITLE
Added adaptivity glue composition

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added type-stable methods to `tensor_contraction` and `Base.permutedims(::MultiValue, perm)`: pass the arguments by `Val`. Since PR[#1301](https://github.com/gridap/Gridap.jl/pull/1301).
+- Added `compose_glues` and `compress_adaptivity`, which are tools that can be used to compress a mesh hierarchy (several levels of refinement) into a single adapted model. Since PR[#1309](https://github.com/gridap/Gridap.jl/pull/1309).
 
 ### Fixed
 

--- a/src/Adaptivity/AdaptedDiscreteModels.jl
+++ b/src/Adaptivity/AdaptedDiscreteModels.jl
@@ -133,3 +133,17 @@ function get_d_to_fface_to_cface(model::AdaptedDiscreteModel)
   glue  = get_adaptivity_glue(model)
   return get_d_to_fface_to_cface(glue,ctopo,ftopo)
 end
+
+# Compressing multiple levels of adaptivity into one
+
+function compress_adaptivity(model::AdaptedDiscreteModel)
+  compress_adaptivity(typeof(model.parent), model)
+end
+
+compress_adaptivity(::Type{<:DiscreteModel}, model) = model
+
+function compress_adaptivity(::Type{<:AdaptedDiscreteModel}, model)
+  parent = compress_adaptivity(model.parent)
+  glue = compose_glues(model.glue, parent.glue)
+  AdaptedDiscreteModel(model.model, parent.parent, glue)
+end

--- a/src/Adaptivity/AdaptivityGlues.jl
+++ b/src/Adaptivity/AdaptivityGlues.jl
@@ -118,6 +118,65 @@ function get_old_cell_refinement_rules(g::AdaptivityGlue)
   return g.refinement_rules
 end
 
+"""
+    compose_glues(glue12::AdaptivityGlue, glue23::AdaptivityGlue)
+
+Given two `AdaptivityGlue`s `glue12` and `glue23`, returns a `RefinementGlue` that corresponds to the composition of the two, i.e., `glue12 ∘ glue23`.
+"""
+function compose_glues(glue12::AdaptivityGlue,glue23::AdaptivityGlue)
+  # TODO: Actually, I think that conceptualy there is no issue? 
+  @notimplemented "compose_glues not implemented for mixed refinement/coarsening glues"
+end
+
+function compose_glues(
+  glue12::AdaptivityGlue{RefinementGlue,Dc},
+  glue23::AdaptivityGlue{RefinementGlue,Dc}
+) where Dc
+
+  n2o_faces_map = Vector{Vector{Int32}}(undef, Dc+1)
+  for d in 0:Dc
+    f1_to_f2 = glue12.n2o_faces_map[d+1]
+    f2_to_f3 = glue23.n2o_faces_map[d+1]
+    f1_to_f3 = zeros(Int32, length(f1_to_f2))
+    for (f1, f2) in enumerate(f1_to_f2)
+      if !iszero(f2)
+        f1_to_f3[f1] = f2_to_f3[f2]
+      end
+    end
+    n2o_faces_map[d+1] = f1_to_f3
+  end
+
+  n3                   = length(glue23.o2n_faces_map)
+  n2o_cells            = n2o_faces_map[Dc+1]
+  o2n_faces_map        = inverse_table(n2o_cells, n3)
+  n2o_cell_to_child_id = find_local_index(n2o_cells, o2n_faces_map)
+
+  rr12s_per_c2    = get_old_cell_refinement_rules(glue12)
+  rr23s_per_c2    = get_new_cell_refinement_rules(glue23)
+  composed_per_c2 = compose_refinement_rules(rr12s_per_c2, rr23s_per_c2)
+
+  c2_to_c3(data::Fill{<:RefinementRule}) = Fill(first(data), n3)
+  function c2_to_c3(data::CompressedArray{<:RefinementRule})
+    first_ptrs = Vector{Int32}(undef, n3)
+    for c3 in 1:n3
+      children = glue23.o2n_faces_map[c3]
+      ptr_ref  = data.ptrs[first(children)]
+      @check(all(c2 -> data.ptrs[c2] == ptr_ref, children),
+        "compose_glues: mesh2 children of mesh3 cell $c3 have different refinement rules")
+      first_ptrs[c3] = ptr_ref
+    end
+    CompressedArray(data.values, first_ptrs)
+  end
+
+  refinement_rules = c2_to_c3(composed_per_c2)
+  is_refined       = select_refined_cells(n2o_faces_map[end])
+
+  return AdaptivityGlue(
+    RefinementGlue(), n2o_faces_map, n2o_cell_to_child_id,
+    refinement_rules, is_refined, o2n_faces_map
+  )
+end
+
 # Data re-indexing
 
 """

--- a/src/Adaptivity/EdgeBasedRefinement.jl
+++ b/src/Adaptivity/EdgeBasedRefinement.jl
@@ -567,6 +567,15 @@ function RedRefinementRule(p::Polytope)
   return RefinementRule(RedRefinement(),p,ref_grid)
 end
 
+function compose_refinement_rules(::RedRefinement, ::WithoutRefinement, rr1, rr2)
+  return rr1
+end
+
+function compose_refinement_rules(::RedRefinement, ::RefinementRuleType, rr1, rr2)
+  amodel = refine(RedGreenRefinement(), get_ref_grid(rr2))
+  return RefinementRule(GenericRefinement(), get_polytope(rr2), get_model(amodel))
+end
+
 function _get_red_refined_faces_list(p::Polytope)
   if p == TRI
     return (Int32[1,2,3],Int32[1,2,3],Int32[])

--- a/src/Adaptivity/RefinementRules.jl
+++ b/src/Adaptivity/RefinementRules.jl
@@ -729,7 +729,31 @@ function ReferenceFEs.get_face_vertex_permutations(rrule::RefinementRule)
   return cface_to_pindex_to_fnodes
 end
 
-# Implementation comment (Jordi): 
+function get_face_own_vertices(rrule::RefinementRule)
+  own_ffaces = get_cface_to_own_ffaces(rrule)
+  topo = get_grid_topology(rrule.ref_grid)
+  node_range = get_dimrange(topo, 0)
+  return [Int[f for f in ffs if f ∈ node_range] for ffs in own_ffaces]
+end
+
+function get_face_own_coordinates(rrule::RefinementRule)
+  own_vertices = get_face_own_vertices(rrule)
+  topo = get_grid_topology(rrule.ref_grid)
+  coords = get_vertex_coordinates(topo)
+  return lazy_map(Broadcasting(Reindex(coords)), own_vertices)
+end
+
+function get_face_own_vertex_permutations(rrule::RefinementRule)
+  cface_to_own_fnodes      = get_face_own_vertices(rrule)
+  cface_to_all_fnodes      = get_face_vertices(rrule)
+  cface_to_pindex_to_order = get_face_vertex_permutations(rrule)
+  return map(cface_to_own_fnodes, cface_to_all_fnodes, cface_to_pindex_to_order) do own_fnodes, all_fnodes, pindex_to_order
+    own_pos = Dict(Int(n) => i for (i, n) in enumerate(own_fnodes))
+    [[own_pos[Int(all_fnodes[pos])] for pos in perm if haskey(own_pos, Int(all_fnodes[pos]))] for perm in pindex_to_order]
+  end
+end
+
+# Implementation comment (Jordi):
 # The function below computes the permutations of the fine nodes on a face, given a permutation 
 # of the coarse nodes on the same face. This is done by comparing coordinates. In general, this is 
 # not the best idea, since we are doing float comparisons. However, I believe this should not be a problem
@@ -874,6 +898,115 @@ function _compute_cface_to_fface_permutations(
   end
 
   return cface_to_cpindex_to_ffaces,cface_to_cpindex_to_fpindex
+end
+
+# Composition of RefinementRules
+
+"""
+    compose_refinement_rules(rr1::RefinementRule, rr2::RefinementRule)
+
+Given two `RefinementRule`s `rr1` and `rr2`, returns a `RefinementRule` that 
+corresponds to the composition of the two, i.e `rr1 ∘ rr2`.
+"""
+function compose_refinement_rules(rr1::RefinementRule, rr2::RefinementRule)
+  compose_refinement_rules(RefinementRuleType(rr1), RefinementRuleType(rr2), rr1, rr2)
+end
+
+compose_refinement_rules(rr, rrs::RefinementRule...) =
+  compose_refinement_rules(rr, compose_refinement_rules(rrs...))
+
+function compose_refinement_rules(::WithoutRefinement, ::RefinementRuleType, rr1, rr2)
+  return rr2
+end
+
+function compose_refinement_rules(::RefinementRuleType, ::WithoutRefinement, rr1, rr2)
+  return rr1
+end
+
+function compose_refinement_rules(::WithoutRefinement, ::WithoutRefinement, rr1, rr2)
+  return rr1
+end
+
+# Fallback method for generic refinement rules.
+function compose_refinement_rules(::RefinementRuleType, ::RefinementRuleType, rr1, rr2)
+  ref_grid2 = get_ref_grid(rr2)
+  topo2     = get_grid_topology(ref_grid2)
+  cmaps2    = get_cell_map(rr2)
+  m2        = num_subcells(rr2)
+
+  rr1_ref_grid  = get_ref_grid(rr1)
+  rr1_coords    = get_node_coordinates(rr1_ref_grid)
+  rr1_fine_conn = get_cell_node_ids(rr1_ref_grid)
+  rr1_reffes    = get_reffes(rr1_ref_grid)
+  rr1_ctypes    = get_cell_type(rr1_ref_grid)
+  nf_cells      = num_subcells(rr1)
+
+  poly1              = get_polytope(rr1)
+  Dc                 = num_cell_dims(poly1)
+  lface_own_ldofs    = get_face_own_vertices(rr1)
+  lface_pindex_pdofs = get_face_own_vertex_permutations(rr1)
+  cell_ctype         = get_cell_type(ref_grid2)
+  @check maximum(cell_ctype) == 1 "compose_refinement_rules: all intermediate cells must share the polytope"
+  cell_conformity = CellConformity(
+    cell_ctype, [lface_own_ldofs], [lface_pindex_pdofs], [[num_faces(poly1, d)] for d in 0:Dc]
+  )
+
+  cell_node_ids, num_nodes, _, _, _ = compute_conforming_cell_dofs(
+    cell_conformity, topo2, get_face_labeling(ref_grid2), Int[]
+  )
+
+  cell_phys_nodes = lazy_map(evaluate, cmaps2, Fill(rr1_coords, m2))
+  global_coords   = gather_table_values(cell_node_ids, cell_phys_nodes, num_nodes)
+
+  block_ptrs      = Int32.(range(1, m2*nf_cells+1, step=nf_cells))
+  composed_ctypes = rr1_ctypes[Arrays.local_identity_array(Int32, block_ptrs)]
+  composed_conn   = Table([Int32.(cell_node_ids[j][rr1_fine_conn[k]]) for j in 1:m2 for k in 1:nf_cells])
+
+  composed_grid  = UnstructuredGrid(global_coords, composed_conn, rr1_reffes, composed_ctypes)
+  composed_model = UnstructuredDiscreteModel(composed_grid)
+  return RefinementRule(GenericRefinement(), get_polytope(rr2), composed_model)
+end
+
+# Array-level compose_refinement_rules
+
+function compose_refinement_rules(::AbstractArray{<:RefinementRule}, ::AbstractArray{<:RefinementRule})
+  @notimplemented
+end
+
+function compose_refinement_rules(rr1s::Fill{<:RefinementRule}, rr2s::Fill{<:RefinementRule})
+  rr = compose_refinement_rules(rr1s.value, rr2s.value)
+  Fill(rr, axes(rr1s))
+end
+
+function compose_refinement_rules(rr1s::CompressedArray{<:RefinementRule}, rr2s::CompressedArray{<:RefinementRule})
+  n = length(rr1s)
+  @assert length(rr2s) == n
+  ptrs1, vals1 = rr1s.ptrs, rr1s.values
+  ptrs2, vals2 = rr2s.ptrs, rr2s.values
+  pair_to_idx = Dict{Tuple{Int32,Int32},Int32}()
+  result_vals = RefinementRule[]
+  result_ptrs = Vector{Int32}(undef, n)
+  for i in 1:n
+    p1 = Int32(ptrs1[i])
+    p2 = Int32(ptrs2[i])
+    result_ptrs[i] = get!(pair_to_idx, (p1, p2)) do
+      push!(result_vals, compose_refinement_rules(vals1[p1], vals2[p2]))
+      Int32(length(result_vals))
+    end
+  end
+  CompressedArray(collect(result_vals), result_ptrs)
+end
+
+function compose_refinement_rules(rr1s::Fill{<:RefinementRule}, rr2s::CompressedArray{<:RefinementRule})
+  n = length(rr1s)
+  ca1 = CompressedArray(RefinementRule[first(rr1s)], fill(Int32(1), n))
+  compose_refinement_rules(ca1, rr2s)
+end
+
+function compose_refinement_rules(rr1s::CompressedArray{<:RefinementRule}, rr2s::Fill{<:RefinementRule})
+  n = length(rr1s)
+  ca2 = CompressedArray(RefinementRule[first(rr2s)], fill(Int32(1), n))
+  compose_refinement_rules(rr1s, ca2)
 end
 
 # IO

--- a/test/AdaptivityTests/AdaptivityCompositionTests.jl
+++ b/test/AdaptivityTests/AdaptivityCompositionTests.jl
@@ -1,0 +1,126 @@
+module AdaptivityCompositionTests
+
+using Test
+using Gridap
+using Gridap.Adaptivity
+using Gridap.ReferenceFEs
+using Gridap.Geometry
+using Gridap.Arrays
+
+rr_white = Adaptivity.WhiteRefinementRule(TRI)
+rr_red   = Adaptivity.RedRefinementRule(TRI)
+rr_bary  = Adaptivity.BarycentricRefinementRule(TRI)
+
+############################################################################################
+# compose_refinement_rules: White identities
+############################################################################################
+
+@test Adaptivity.compose_refinement_rules(rr_white, rr_red)  === rr_red
+@test Adaptivity.compose_refinement_rules(rr_red,   rr_white) === rr_red
+@test Adaptivity.compose_refinement_rules(rr_white, rr_bary) === rr_bary
+@test Adaptivity.compose_refinement_rules(rr_bary,  rr_white) === rr_bary
+@test Adaptivity.RefinementRuleType(Adaptivity.compose_refinement_rules(rr_white, rr_white)) isa Adaptivity.WithoutRefinement
+
+############################################################################################
+# compose_refinement_rules: Red ∘ Red
+############################################################################################
+
+rr_red2 = Adaptivity.compose_refinement_rules(rr_red, rr_red)
+@test Adaptivity.RefinementRuleType(rr_red2) isa Adaptivity.GenericRefinement
+@test Adaptivity.get_polytope(rr_red2) == TRI
+@test Adaptivity.num_subcells(rr_red2) == Adaptivity.num_subcells(rr_red)^2
+
+############################################################################################
+# compose_refinement_rules: generic fallback (Bary ∘ Red and Red ∘ Bary)
+############################################################################################
+
+# Bary ∘ Red: Red splits into 4, Bary splits each into 3 → 12
+rr_bary_red = Adaptivity.compose_refinement_rules(rr_bary, rr_red)
+@test Adaptivity.RefinementRuleType(rr_bary_red) isa Adaptivity.GenericRefinement
+@test Adaptivity.get_polytope(rr_bary_red) == TRI
+@test Adaptivity.num_subcells(rr_bary_red) == Adaptivity.num_subcells(rr_red) * Adaptivity.num_subcells(rr_bary)
+
+# Red ∘ Bary: Bary splits into 3, Red splits each into 4 → 12
+rr_red_bary = Adaptivity.compose_refinement_rules(rr_red, rr_bary)
+@test Adaptivity.RefinementRuleType(rr_red_bary) isa Adaptivity.GenericRefinement
+@test Adaptivity.get_polytope(rr_red_bary) == TRI
+@test Adaptivity.num_subcells(rr_red_bary) == Adaptivity.num_subcells(rr_bary) * Adaptivity.num_subcells(rr_red)
+
+############################################################################################
+# compose_refinement_rules: varargs (Red ∘ Red ∘ Red = 4^3 = 64)
+############################################################################################
+
+rr_red3 = Adaptivity.compose_refinement_rules(rr_red, rr_red, rr_red)
+@test Adaptivity.RefinementRuleType(rr_red3) isa Adaptivity.GenericRefinement
+@test Adaptivity.num_subcells(rr_red3) == Adaptivity.num_subcells(rr_red)^3
+
+############################################################################################
+# compose_glues: two successive coarsenings of a simplexified voronoi mesh
+############################################################################################
+
+model1 = Geometry.voronoi(Geometry.simplexify(CartesianDiscreteModel((0,1,0,1),(3,3))))
+
+pcells1 = Table([
+  LinearIndices((4,4))[1:2,1:2],
+  LinearIndices((4,4))[3:4,1:2],
+  LinearIndices((4,4))[1:2,3:4],
+  LinearIndices((4,4))[3:4,3:4],
+])
+ptopo1 = Geometry.PatchTopology(get_grid_topology(model1), pcells1)
+model2, glue12 = Adaptivity.coarsen(model1, ptopo1; return_glue=true)
+
+pcells2 = Table([[1,2],[3,4]])
+ptopo2 = Geometry.PatchTopology(get_grid_topology(model2), pcells2)
+model3, glue23 = Adaptivity.coarsen(model2, ptopo2; return_glue=true)
+
+glue13 = Adaptivity.compose_glues(glue12, glue23)
+
+Dc    = 2
+topo1 = get_grid_topology(model1)
+topo3 = get_grid_topology(model3)
+
+# Face maps: length and zero-count checks for d = 0, 1, 2
+for d in 0:Dc
+  n2o = glue13.n2o_faces_map[d+1]
+  @test length(n2o) == num_faces(topo1, d)
+  if d == Dc
+    @test count(iszero, n2o) == 0
+  else
+    @test count(!iszero, n2o) == num_faces(topo3, d)
+  end
+end
+
+# Refinement rules: one per mesh3 cell, polytope matches glue23
+n3 = num_cells(topo3)
+@test length(glue13.refinement_rules) == n3
+for rr in glue13.refinement_rules
+  @test Adaptivity.get_polytope(rr) == Adaptivity.get_polytope(glue23.refinement_rules[1])
+end
+
+############################################################################################
+# compress_adaptivity: 3-level uniform red refinement on TRI
+############################################################################################
+
+base_tri = Geometry.simplexify(CartesianDiscreteModel((0,1,0,1),(3,3)))
+m4_tri   = refine(refine(refine(base_tri)))
+c_tri    = Adaptivity.compress_adaptivity(m4_tri)
+
+@test num_cells(c_tri.model) == num_cells(base_tri) * 4^3
+@test !isa(c_tri.parent, AdaptedDiscreteModel)
+@test length(c_tri.glue.refinement_rules) == num_cells(base_tri)
+@test all(rr -> Adaptivity.num_subcells(rr) == 4^3, c_tri.glue.refinement_rules)
+
+############################################################################################
+# compress_adaptivity: 3-level uniform red refinement on QUAD
+############################################################################################
+
+base_quad = Geometry.UnstructuredDiscreteModel(CartesianDiscreteModel((0,1,0,1),(3,3)))
+m4_quad   = refine(refine(refine(base_quad)))
+c_quad    = Adaptivity.compress_adaptivity(m4_quad)
+
+@test num_cells(c_quad.model) == num_cells(base_quad) * 4^3
+@test !isa(c_quad.parent, AdaptedDiscreteModel)
+@test length(c_quad.glue.refinement_rules) == num_cells(base_quad)
+@test all(rr -> Adaptivity.num_subcells(rr) == 4^3, c_quad.glue.refinement_rules)
+
+end # module

--- a/test/AdaptivityTests/runtests.jl
+++ b/test/AdaptivityTests/runtests.jl
@@ -32,4 +32,8 @@ end
   include("PolytopalCoarseningTests.jl")
 end
 
+@testset "AdaptivityComposition" begin
+  include("AdaptivityCompositionTests.jl")
+end
+
 end # module


### PR DESCRIPTION
This PR adds `compose_glues` and `compress_adaptivity`, which are tools that can be used to compress a mesh hierarchy (several levels of refinement) into a single adapted model. 