### PR TITLE
Consistent Linear-Algebra exports: normalize and eigen

### DIFF
--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -6,8 +6,8 @@ macro publish(mod,name)
 end
 
 # Reexport from LinearAlgebra (just for convenience)
-using LinearAlgebra:  det, inv, tr, cross, dot, norm, ×, ⋅
-export det, inv, tr, cross, dot, norm, ×, ⋅
+using LinearAlgebra:  det, inv, tr, cross, dot, norm, normalize, eigen, ×, ⋅
+export det, inv, tr, cross, dot, norm, normalize, eigen, ×, ⋅
 
 @publish Helpers GridapType
 


### PR DESCRIPTION
In #1157 and #1211 there were added the corresponding dispatches for `LinearAlgebra.eigen` and `LinearAlgebra.normalize` with `TensorValue`. These functions are currently exported in `TensorValues` module, but not in the `Gridap` namespace.

This PR makes the exports consistent between
https://github.com/gridap/Gridap.jl/blob/eabb7e568a19a822f2fbbef82e4e7833bd2f837b/src/TensorValues/TensorValues.jl#L108
and
https://github.com/gridap/Gridap.jl/blob/eabb7e568a19a822f2fbbef82e4e7833bd2f837b/src/Exports.jl#L10