### PR TITLE
Own face_dof[_perm] stored by default in ReferenceFE s

### DIFF
--- a/src/Adaptivity/MacroFEs.jl
+++ b/src/Adaptivity/MacroFEs.jl
@@ -370,10 +370,10 @@ function MacroReferenceFE(
   poly = get_polytope(rrule)
   # This is a hack to be able to compute the orders
   prebasis = FineToCoarseArray(rrule,collect(map(get_prebasis,reffes)))
-  metadata = (rrule,conn,face_dofs,face_own_perms)
+  metadata = (rrule,conn,face_dofs)
 
   return GenericRefFE{Name}(
-    ndofs,poly,prebasis,dofs,conformity,metadata,face_own_dofs,basis
+    ndofs,poly,prebasis,dofs,conformity,metadata,face_own_dofs,basis,face_own_perms
   )
 end
 
@@ -388,7 +388,7 @@ end
 
 function ReferenceFEs.get_face_dofs(reffe::GenericRefFE{<:MacroRefFEName}, conf::Conformity)
   @check conf == Conformity(reffe)
-  rrule,conn,face_dofs,face_own_perms = ReferenceFEs.get_metadata(reffe)
+  rrule,conn,face_dofs = ReferenceFEs.get_metadata(reffe)
   return face_dofs
 end
 
@@ -397,19 +397,8 @@ function ReferenceFEs.get_face_own_dofs(reffe::GenericRefFE{<:MacroRefFEName}, c
   return reffe.face_own_dofs
 end
 
-function ReferenceFEs.get_face_own_dofs_permutations(reffe::GenericRefFE{<:MacroRefFEName}, conf::Conformity)
-  @check conf == Conformity(reffe)
-  rrule,conn,face_dofs,face_own_perms = ReferenceFEs.get_metadata(reffe)
-  return face_own_perms
-end
-
 function ReferenceFEs.get_face_own_dofs(reffe::GenericRefFE{<:MacroRefFEName}, ::L2Conformity)
   return ReferenceFEs.l2_face_own_dofs(reffe)
-end
-
-function ReferenceFEs.get_face_own_dofs_permutations(reffe::GenericRefFE{<:MacroRefFEName}, ::L2Conformity)
-  face_own_dofs = ReferenceFEs.get_face_own_dofs(reffe, L2Conformity())
-  return ReferenceFEs.l2_face_own_dofs_permutations(face_own_dofs)
 end
 
 """

--- a/src/ReferenceFEs/BezierRefFEs.jl
+++ b/src/ReferenceFEs/BezierRefFEs.jl
@@ -85,6 +85,9 @@ end
 
 get_face_own_dofs(reffe::BezierRefFE) = get_face_own_dofs(reffe.reffe)
 
+get_face_own_dofs_permutations(reffe::BezierRefFE) =
+  get_face_own_dofs_permutations(reffe.reffe)
+
 get_face_dofs(reffe::BezierRefFE) = get_face_dofs(reffe.reffe)
 
 num_dofs(reffe::BezierRefFE) = num_dofs(reffe.reffe)

--- a/src/ReferenceFEs/CDLagrangianRefFEs.jl
+++ b/src/ReferenceFEs/CDLagrangianRefFEs.jl
@@ -33,6 +33,22 @@ function get_face_own_nodes(reffe::GenericLagrangianRefFE{GradConformity},conf::
   _cd_get_face_own_nodes(reffe,conf)
 end
 
+function get_face_own_dofs(reffe::LagrangianRefFE,conf::CDConformity)
+  face_own_nodes = get_face_own_nodes(reffe,conf)
+  node_and_comp_to_dof = get_node_and_comp_to_dof(reffe)
+  face_own_dofs = _generate_face_own_dofs(face_own_nodes, node_and_comp_to_dof)
+  face_own_dofs
+end
+
+function get_face_own_dofs_permutations(reffe::LagrangianRefFE, conf::CDConformity)
+  face_own_nodes_permutations = get_face_own_nodes_permutations(reffe, conf)
+  node_and_comp_to_dof = get_node_and_comp_to_dof(reffe)
+  face_own_nodes = get_face_own_nodes(reffe, conf)
+  face_own_dofs = get_face_own_dofs(reffe, conf)
+  _generate_face_own_dofs_permutations(
+    face_own_nodes_permutations, node_and_comp_to_dof, face_own_nodes, face_own_dofs)
+end
+
 # Constructors
 
 function _CDLagrangianRefFE(::Type{T},p::ExtrusionPolytope{D},order::Int,cont) where {T,D}
@@ -62,6 +78,10 @@ function _cd_lagrangian_ref_fe(::Type{T},p::ExtrusionPolytope{D},orders,cont) wh
 
   face_own_dofs = _generate_face_own_dofs(face_own_nodes, dofs.node_and_comp_to_dof)
 
+  face_own_nodes_permutations = l2_face_own_dofs_permutations(face_own_nodes)
+  face_own_dofs_permutations = _generate_face_own_dofs_permutations(
+    face_own_nodes_permutations, dofs.node_and_comp_to_dof, face_own_nodes, face_own_dofs)
+
   data = nothing
 
   conf = CDConformity(Tuple(cont))
@@ -73,7 +93,8 @@ function _cd_lagrangian_ref_fe(::Type{T},p::ExtrusionPolytope{D},orders,cont) wh
       dofs,
       conf,
       data,
-      face_own_dofs)
+      face_own_dofs,
+      face_own_dofs_permutations)
 
   GenericLagrangianRefFE(reffe,face_nodes)
 end

--- a/src/ReferenceFEs/CLagrangianRefFEs.jl
+++ b/src/ReferenceFEs/CLagrangianRefFEs.jl
@@ -245,7 +245,7 @@ end
 
 function _lagrangian_ref_fe(::Type{T},p::Polytope{D},orders,poly_type) where {T,D}
 
-  basis = compute_poly_basis(T,p,orders,poly_type)
+  prebasis = compute_poly_basis(T,p,orders,poly_type)
   nodes, face_own_nodes = compute_nodes(p,orders)
   dofs = LagrangianDofBasis(T,nodes)
   reffaces = compute_lagrangian_reffaces(T,p,orders)
@@ -257,21 +257,22 @@ function _lagrangian_ref_fe(::Type{T},p::Polytope{D},orders,poly_type) where {T,
   face_nodes = _generate_face_nodes(nnodes,face_own_nodes,p,_reffaces)
   face_own_dofs = _generate_face_own_dofs(face_own_nodes, dofs.node_and_comp_to_dof)
 
-  if all(map(i->i==0,orders) ) && D>0
-    conf = L2Conformity()
-  else
-    conf = GradConformity()
-  end
+  conf = (all(map(i->i==0,orders) ) && D>0) ? L2Conformity() : GradConformity()
 
-  reffe = GenericRefFE{typeof(conf)}(
-    ndofs,
-    p,
-    basis, # pre-basis
-    dofs,
-    conf,
-    metadata,
-    face_own_dofs)
-  GenericLagrangianRefFE(reffe,face_nodes)
+  reffe = GenericRefFE{typeof(conf)}(ndofs, p, prebasis, dofs, conf, metadata, face_own_dofs)
+  lag_reffe = GenericLagrangianRefFE(reffe,face_nodes)
+
+  # compute and fill face_own_dofs_permutations
+  face_own_dofs_permutations = if conf isa L2Conformity
+     l2_face_own_dofs_permutations(face_own_dofs)
+  else # GradConformity
+    face_own_nodes_permutations = get_face_own_nodes_permutations(lag_reffe)
+    face_own_dofs_permutations = _generate_face_own_dofs_permutations(
+      face_own_nodes_permutations, dofs.node_and_comp_to_dof, face_own_nodes, face_own_dofs)
+  end
+  append!.(reffe.face_own_dofs_permutations, face_own_dofs_permutations)
+
+  lag_reffe
 end
 
 function monomial_basis(::Type{T},p::Polytope,orders) where T

--- a/src/ReferenceFEs/LagrangianRefFEs.jl
+++ b/src/ReferenceFEs/LagrangianRefFEs.jl
@@ -246,13 +246,6 @@ function get_face_nodes(reffe::LagrangianRefFE,d::Integer)
   get_face_nodes(reffe)[range]
 end
 
-function get_face_own_dofs(reffe::LagrangianRefFE,conf::Conformity)
-  face_own_nodes = get_face_own_nodes(reffe,conf)
-  node_and_comp_to_dof = get_node_and_comp_to_dof(reffe)
-  face_own_dofs = _generate_face_own_dofs(face_own_nodes, node_and_comp_to_dof)
-  face_own_dofs
-end
-
 function _generate_face_own_dofs(face_own_nodes, node_and_comp_to_dof)
   faces = 1:length(face_own_nodes)
   T = eltype(node_and_comp_to_dof)
@@ -272,16 +265,6 @@ function _generate_face_own_dofs(face_own_nodes, node_and_comp_to_dof)
 
   face_own_dofs
 
-end
-
-function get_face_own_dofs_permutations(reffe::LagrangianRefFE,conf::Conformity)
-  face_own_nodes_permutations = get_face_own_nodes_permutations(reffe,conf)
-  node_and_comp_to_dof = get_node_and_comp_to_dof(reffe)
-  face_own_nodes = get_face_own_nodes(reffe,conf)
-  face_own_dofs = get_face_own_dofs(reffe,conf)
-  face_own_dofs_permutations = _generate_face_own_dofs_permutations(
-    face_own_nodes_permutations, node_and_comp_to_dof, face_own_nodes, face_own_dofs)
-  face_own_dofs_permutations
 end
 
 function  _generate_face_own_dofs_permutations(
@@ -320,11 +303,6 @@ function  _generate_face_own_dofs_permutations(
     push!(face_own_dofs_permutations,pindex_to_idof_to_pidof)
   end
   face_own_dofs_permutations
-end
-
-function get_face_own_dofs_permutations(reffe::LagrangianRefFE, conf::L2Conformity)
-  face_own_dofs = get_face_own_dofs(reffe,conf)
-  l2_face_own_dofs_permutations(face_own_dofs)
 end
 
 """
@@ -407,6 +385,9 @@ get_dof_basis(reffe::GenericLagrangianRefFE) = get_dof_basis(reffe.reffe)
 Conformity(reffe::GenericLagrangianRefFE) = Conformity(reffe.reffe)
 
 get_face_own_dofs(reffe::GenericLagrangianRefFE) = get_face_own_dofs(reffe.reffe)
+
+get_face_own_dofs_permutations(reffe::GenericLagrangianRefFE) =
+  get_face_own_dofs_permutations(reffe.reffe)
 
 get_face_dofs(reffe::GenericLagrangianRefFE) = get_face_dofs(reffe.reffe)
 

--- a/src/ReferenceFEs/ModalC0RefFEs.jl
+++ b/src/ReferenceFEs/ModalC0RefFEs.jl
@@ -49,7 +49,8 @@ function ModalC0RefFE(
 
   shapefuns = ModalC0Basis{D}(T,orders,a,b)
 
-  ndofs, predofs, lag_reffe, face_own_dofs = compute_reffe_data(T,p,orders,space=space)
+  ndofs, predofs, lag_reffe, face_own_dofs, face_own_dofs_permutations =
+    compute_reffe_data(T,p,orders,space=space)
 
   GenericRefFE{ModalC0}(
     ndofs,
@@ -58,7 +59,8 @@ function ModalC0RefFE(
     GradConformity(),
     lag_reffe,
     face_own_dofs,
-    shapefuns)
+    shapefuns,
+    face_own_dofs_permutations)
 end
 
 function ModalC0RefFE(
@@ -72,7 +74,8 @@ function ModalC0RefFE(
 
   shapefuns = ModalC0Basis{D}(T,orders)
 
-  ndofs, predofs, lag_reffe, face_own_dofs = compute_reffe_data(T,p,orders,space=space)
+  ndofs, predofs, lag_reffe, face_own_dofs, face_own_dofs_permutations =
+    compute_reffe_data(T,p,orders,space=space)
 
   GenericRefFE{ModalC0}(
     ndofs,
@@ -81,7 +84,8 @@ function ModalC0RefFE(
     GradConformity(),
     lag_reffe,
     face_own_dofs,
-    shapefuns)
+    shapefuns,
+    face_own_dofs_permutations)
 end
 
 function get_orders(reffe::GenericRefFE{ModalC0,D}) where{D}
@@ -102,7 +106,7 @@ function compute_reffe_data(::Type{T},
                             space::Symbol=_default_space(p)) where {T,D}
   lag_reffe = LagrangianRefFE(T,p,orders,space=space)
   reffe = lag_reffe.reffe
-  reffe.ndofs, reffe.dofs, lag_reffe, reffe.face_own_dofs
+  reffe.ndofs, reffe.dofs, lag_reffe, reffe.face_own_dofs, reffe.face_own_dofs_permutations
 end
 
 function ReferenceFE(
@@ -112,12 +116,6 @@ function ReferenceFE(
   orders::Union{Integer,NTuple{D,Int}};
   kwargs...) where {T,D}
   ModalC0RefFE(T,polytope,orders;kwargs...)
-end
-
-function get_face_own_dofs_permutations(
-  reffe::GenericRefFE{ModalC0},conf::GradConformity)
-  lagrangian_reffe = reffe.metadata
-  get_face_own_dofs_permutations(lagrangian_reffe,conf)
 end
 
 function compute_shapefun_bboxes!(
@@ -149,7 +147,8 @@ function compute_cell_to_modalC0_reffe(
   @notimplementedif minimum(orders) < one(eltype(orders))
   @assert ncells == length(bboxes)
 
-  ndofs, predofs, lag_reffe, face_own_dofs = compute_reffe_data(T,p,orders,space=space)
+  ndofs, predofs, lag_reffe, face_own_dofs, face_own_dofs_permutations =
+    compute_reffe_data(T,p,orders,space=space)
 
   filter = space == :Q ? _q_filter : _ser_filter
 
@@ -166,7 +165,8 @@ function compute_cell_to_modalC0_reffe(
                                     GradConformity(),
                                     lag_reffe,
                                     face_own_dofs,
-                                    sh)
+                                    sh,
+                                    face_own_dofs_permutations)
 
   reffes = [ reffe(sh(bbs)) for bbs in bboxes ]
   CompressedArray(reffes,1:ncells)
@@ -184,14 +184,16 @@ function compute_cell_to_modalC0_reffe(
 
   filter = space == :Q ? _q_filter : _ser_filter
 
-  ndofs, predofs, lag_reffe, face_own_dofs = compute_reffe_data(T,p,orders,space=space)
+  ndofs, predofs, lag_reffe, face_own_dofs, face_own_dofs_permutations =
+    compute_reffe_data(T,p,orders,space=space)
   reffe = GenericRefFE{ModalC0}(ndofs,
                                 p,
                                 predofs,
                                 GradConformity(),
                                 lag_reffe,
                                 face_own_dofs,
-                                ModalC0Basis{D}(T,orders,filter=filter))
+                                ModalC0Basis{D}(T,orders,filter=filter),
+                                face_own_dofs_permutations)
 
   Fill(reffe,ncells)
 end

--- a/src/ReferenceFEs/PDiscRefFEs.jl
+++ b/src/ReferenceFEs/PDiscRefFEs.jl
@@ -18,6 +18,7 @@ function _PDiscRefFE(::Type{V},p::Polytope,order::Integer, poly_type) where V
   basis = FEEC_poly_basis(Val(D),V,order,D,:S,poly_type; cart_prod=(V <: MultiValue))
   dofs = get_dof_basis(reffe)
   face_own_dofs = _generate_face_own_dofs(face_nodes,dofs.node_and_comp_to_dof)
+  face_own_dofs_permutations = l2_face_own_dofs_permutations(face_own_dofs)
 
   conf = L2Conformity()
 
@@ -28,7 +29,8 @@ function _PDiscRefFE(::Type{V},p::Polytope,order::Integer, poly_type) where V
     dofs,
     conf,
     metadata,
-    face_own_dofs)
+    face_own_dofs,
+    face_own_dofs_permutations)
   GenericLagrangianRefFE(reffe,face_nodes)
 end
 

--- a/src/ReferenceFEs/ReferenceFEInterfaces.jl
+++ b/src/ReferenceFEs/ReferenceFEInterfaces.jl
@@ -261,34 +261,35 @@ none are glued (e.g. for discontinuous Galerkin methods).
 If `conf` is given, the ownership is computed for `conf` and not for `reffe`'s
 conformity. If `d` is given, the returned vector only contains the data for the
 `d`-dimensional faces of  `reffe`'s polytope.
+
+To implement a new ReferenceFE type, overloading `get_face_own_dofs(reffe)` is
+necessary, and `get_face_own_dofs(reffe, conf)` is optional.
 """
-function get_face_own_dofs(reffe::ReferenceFE, conf::Conformity)
+function get_face_own_dofs(::ReferenceFE)
   @abstractmethod
 end
 
-function Conformity(reffe::ReferenceFE, conf::Conformity)
-  conf
-end
-
-function Conformity(reffe::ReferenceFE, conf::Nothing)
-  Conformity(reffe)
-end
-
-function get_face_own_dofs(reffe::ReferenceFE)
-  conf = Conformity(reffe)
-  get_face_own_dofs(reffe, conf)
-end
-
-function get_face_own_dofs(reffe::ReferenceFE, conf::Nothing)
+function get_face_own_dofs(reffe::ReferenceFE, conf::Conformity)
+  conf != Conformity(reffe) && @unreachable """\n
+  It is not possible to use conformity $conf on this reference FE, $reffe.
+  """
   get_face_own_dofs(reffe)
 end
+function get_face_own_dofs(reffe::ReferenceFE, conf::L2Conformity)
+  l2_face_own_dofs(reffe)
+end
+
+get_face_own_dofs(reffe::ReferenceFE, conf::Nothing) = get_face_own_dofs(reffe)
 
 function l2_face_own_dofs(reffe::ReferenceFE)
   p = get_polytope(reffe)
-  r = [Int[] for i in 1:num_faces(p)]
+  r = fill(Int[], num_faces(p))
   r[end] = collect(1:num_dofs(reffe))
   r
 end
+
+Conformity(reffe::ReferenceFE, conf::Conformity) = conf
+Conformity(reffe::ReferenceFE, conf::Nothing) = Conformity(reffe)
 
 """
     get_face_own_dofs_permutations(
@@ -308,13 +309,29 @@ relabeling of the vertices does not exist (i.e., lagrangian FEs on `QUAD` with
 anisotropic order). For these permutations the corresponding vector in
 `get_face_own_dofs_permutations(reffe)` has to be filled with the constant value
 [`INVALID_PERM`](@ref).
+
+To implement a new ReferenceFE type, overloading `get_face_own_dofs_permutations(reffe)`
+is necessary, and `get_face_own_dofs_permutations(reffe, conf)` is optional.
 """
-function get_face_own_dofs_permutations(reffe::ReferenceFE, conf::Conformity)
-  face_own_dofs = get_face_own_dofs(reffe, conf)
-  l2_face_own_dofs_permutations(face_own_dofs)
-  #empty_face_own_dofs_permutations(face_own_dofs)
+function get_face_own_dofs_permutations(::ReferenceFE)
+  @abstractmethod
 end
 
+function get_face_own_dofs_permutations(reffe::ReferenceFE, conf::Conformity)
+  conf != Conformity(reffe) && @unreachable """\n
+  It is not possible to use conformity $conf on this reference FE, $reffe.
+  """
+  get_face_own_dofs_permutations(reffe)
+end
+
+function get_face_own_dofs_permutations(reffe::ReferenceFE, conf::L2Conformity)
+  conf == Conformity(reffe) && return get_face_own_dofs_permutations(reffe)
+  l2_face_own_dofs_permutations(get_face_own_dofs(reffe, conf))
+end
+
+"""
+    l2_face_own_dofs_permutations(face_own_dofs) = [[collect(Int, 1:length(dofs)),] for dofs in face_own_dofs]
+"""
 function l2_face_own_dofs_permutations(face_own_dofs)
   [[collect(Int, 1:length(dofs)),] for dofs in face_own_dofs]
 end
@@ -324,11 +341,6 @@ end
 """
 function empty_face_own_dofs_permutations(face_own_dofs)
   [Vector{Int}[] for _ in face_own_dofs]
-end
-
-function get_face_own_dofs_permutations(reffe::ReferenceFE)
-  conf = Conformity(reffe)
-  get_face_own_dofs_permutations(reffe, conf)
 end
 
 function get_face_own_dofs_permutations(reffe::ReferenceFE, conf::Nothing)
@@ -347,7 +359,9 @@ If `d` is given, the returned vector only contains the data for the
 `d`-dimensional faces of `reffe`'s polytope.
 """
 function get_face_dofs(reffe::ReferenceFE)
-  @abstractmethod
+  poly = get_polytope(reffe)
+  face_own_dofs = get_face_own_dofs(reffe)
+  face_own_data_to_face_data(poly, face_own_dofs)
 end
 
 function get_dof_to_comp(reffe::ReferenceFE)
@@ -618,6 +632,10 @@ This type is a *materialization* of the `ReferenceFE` interface. That is, it is 
 This type is useful to build reference FEs from the underlying ingredients without
 the need to create a new type.
 
+`reffe::GenericRefFE` is meant to store the `face_own_dofs` and
+`face_own_dofs_permutations` for its conformity. No overload of their getters
+are needed for `reffe`'s conformity nor for `L2Conformity()`.
+
 Note that some fields in this `struct` are abstractly typed deliberately in
 order to simplify the type signature.
 """
@@ -647,7 +665,7 @@ order to simplify the type signature.
 
   Constructor using a DoF basis and function space pre-basis.
 
-  The default `face_own_dofs_permutations` is [`l2_face_own_dofs_permutations(face_own_dofs)`](@ref).
+  The default `face_own_dofs_permutations` is [`empty_face_own_dofs_permutations(face_own_dofs)`](@ref).
   """
   function GenericRefFE{T}(
     ndofs::Int,
@@ -658,7 +676,7 @@ order to simplify the type signature.
     metadata,
     face_own_dofs::Vector{Vector{Int}},
     shapefuns::AbstractVector{<:Field}=compute_shapefuns(dofs, prebasis),
-    face_own_dofs_permutations::Vector{Vector{Vector{Int}}}=l2_face_own_dofs_permutations(face_own_dofs),
+    face_own_dofs_permutations::Vector{Vector{Vector{Int}}}=empty_face_own_dofs_permutations(face_own_dofs),
   ) where {T,D}
 
     new{T,D}(
@@ -690,7 +708,7 @@ order to simplify the type signature.
 
   Constructor using shape function basis and a DoF pre-basis.
 
-  The default `face_own_dofs_permutations` is [`l2_face_own_dofs_permutations(face_own_dofs)`](@ref).
+  The default `face_own_dofs_permutations` is [`empty_face_own_dofs_permutations(face_own_dofs)`](@ref).
   """
   function GenericRefFE{T}(
     ndofs::Int,
@@ -701,7 +719,7 @@ order to simplify the type signature.
     face_own_dofs::Vector{Vector{Int}},
     shapefuns::AbstractVector{<:Field},
     dofs::AbstractVector{<:Dof}=compute_dofs(predofs, shapefuns),
-    face_own_dofs_permutations::Vector{Vector{Vector{Int}}}=l2_face_own_dofs_permutations(face_own_dofs),
+    face_own_dofs_permutations::Vector{Vector{Vector{Int}}}=empty_face_own_dofs_permutations(face_own_dofs),
   ) where {T,D}
 
     new{T,D}(
@@ -759,28 +777,8 @@ get_dof_basis(reffe::GenericRefFE) = reffe.dofs
 Conformity(reffe::GenericRefFE) = reffe.conformity
 
 get_face_own_dofs(reffe::GenericRefFE) = reffe.face_own_dofs
-function get_face_own_dofs(reffe::GenericRefFE, conf::Conformity)
-  conf == Conformity(reffe) && return reffe.face_own_dofs
-  conf isa L2Conformity && return l2_face_own_dofs(reffe)
-  @unreachable """\n
-  It is not possible to use conformity $conf on this reference FE.
-  """
-end
-
-function get_face_dofs(reffe::GenericRefFE)
-  poly = get_polytope(reffe)
-  face_own_dofs = get_face_own_dofs(reffe)
-  face_own_data_to_face_data(poly, face_own_dofs)
-end
 
 get_face_own_dofs_permutations(reffe::GenericRefFE) = reffe.face_own_dofs_permutations
-function get_face_own_dofs_permutations(reffe::GenericRefFE, conf::Conformity)
-  conf == Conformity(reffe) && return reffe.face_own_dofs_permutations
-  conf isa L2Conformity && return l2_face_own_dofs_permutations(get_face_own_dofs(reffe, conf))
-  @unreachable """\n
-  It is not possible to use conformity $conf on this reference FE.
-  """
-end
 
 get_shapefuns(reffe::GenericRefFE) = reffe.shapefuns
 


### PR DESCRIPTION
I refactored the `get_face_own_dofs` and `get_face_own_dofs_permutations` methods to accomodate the fact that both are now stored in `GenericRefFE` by default. So the new default method (to overlead) is the single `reffe` argument method, and the `conf::L2Conformity` fallbacks are generic.

Only two overloads for the 2 arg methods are needed now, for `CDConformity` on Lag reffes.

This is breaking for ReferenceFE we don't implement ourselves (only), so I don't push it into `moment-based`, but keep it for next breaking...

Note: I think it would also make sense  to do the same with `face_own_nodes` and `get_face_own_nodes_permutations` of the LagrangianRefFE.