### PR TITLE
Get ftype when change domain on empty adapt trian

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed evaluation of weak forms on empty trians with inverse maps. Since PR[#1316](https://github.com/gridap/Gridap.jl/pull/1316).
+- Fixed getting field type when changing domain on empty adapted triangulations. Since PR [#1326](https://github.com/gridap/Gridap.jl/pull/1326).
 
 ## [0.20.8] - 2026-06-01
 

--- a/src/Adaptivity/AdaptedTriangulations.jl
+++ b/src/Adaptivity/AdaptedTriangulations.jl
@@ -320,7 +320,7 @@ function change_domain_o2n(f_coarse,ctrian::Triangulation{Dc},ftrian::AdaptedTri
 
     return CellData.similar_cell_field(f_coarse,f_fine,ftrian,ReferenceDomain())
   else
-    f_fine = Fill(Fields.ConstantField(0.0),num_cells(ftrian))
+    f_fine = Fill(zero(testitem(CellData.get_data(f_coarse))),num_cells(ftrian))
     return CellData.similar_cell_field(f_coarse,f_fine,ftrian,ReferenceDomain())
   end
 end
@@ -359,7 +359,7 @@ function change_domain_o2n(
 
     return CellData.similar_cell_field(f_old,field_array,new_trian,ReferenceDomain())
   else
-    f_new = Fill(Fields.ConstantField(0.0),num_cells(new_trian))
+    f_new = Fill(zero(testitem(CellData.get_data(f_old))),num_cells(new_trian))
     return CellData.similar_cell_field(f_old,f_new,new_trian,ReferenceDomain())
   end 
 end
@@ -398,7 +398,7 @@ function change_domain_n2o(f_fine,ftrian::AdaptedTriangulation{Dc},ctrian::Trian
 
     return CellData.similar_cell_field(f_fine,f_coarse,ctrian,ReferenceDomain())
   else
-    f_coarse = Fill(Fields.ConstantField(0.0),num_cells(fcoarse))
+    f_coarse = Fill(zero(testitem(CellData.get_data(f_fine))),num_cells(ctrian))
     return CellData.similar_cell_field(f_fine,f_coarse,ctrian,ReferenceDomain())
   end
 end


### PR DESCRIPTION
Hello @JordiManyer,

Here is a small PR with a fix when changing domain on empty adapted trians. The previous implementations of `change_domain`  where assuming the field was scalar. Now, it does not assume that and returns a `ZeroField`, instead of a `ConstantField`.

Lmk if you have any suggestions for improvement. Otherwise, thanks a lot for accepting the PR.

Cheers,
Eric