### PR TITLE
simplified BernsteinBasisOnSimplex

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed evaluation of weak forms on empty trians with inverse maps. Since PR[#1316](https://github.com/gridap/Gridap.jl/pull/1316).
 - Fixed getting field type when changing domain on empty adapted triangulations. Since PR [#1326](https://github.com/gridap/Gridap.jl/pull/1326).
 
+### Changed
+
+- Simplified the type parameters of `BernsteinBasisOnSimplex` and `BarycentricP(m)ΛBasisChanged`. The change of coordinate matrix is always stored, with `Float64` precision. Since PR[#1330](https://github.com/gridap/Gridap.jl/pull/1330).
+
 ## [0.20.8] - 2026-06-01
 
 ### Added

--- a/docs/src/dev-notes/bernstein.md
+++ b/docs/src/dev-notes/bernstein.md
@@ -37,8 +37,7 @@ we have ``∂_{x_i} λ_j(\bm{x}) = M_{j,i+1}``, so
 ```
 The matrix ``M`` is all we need that depends on ``T`` in order to compute
 Bernstein polynomials and their derivatives, it is stored in the field
-`cart_to_bary_matrix` of [`BernsteinBasisOnSimplex`](@ref), when ``T`` is not
-the reference simplex.
+`x_to_λ` of [`BernsteinBasisOnSimplex`](@ref).
 
 On the reference simplex defined by the vertices `get_vertex_coordinates(SEGMENT / TRI / TET⋯)`:
 ```math
@@ -49,7 +48,7 @@ v_2     & = (0\ 1\ ⋯\ 0), \\
 v_N     & = (0\ ⋯\ 0\ 1),
 \end{aligned}
 ```
-the matrix ``M`` is not stored because
+the matrix ``M`` reduces to
 ```math
 λ(\bm{x}) = \Big(1-∑_{1≤ i≤ D} x_i, x_1, x_2, ⋯, x_D\Big)
 \quad\text{and}\quad
@@ -139,9 +138,7 @@ the gradient and hessian compute the ``B_β`` using
 `_downwards_de_Casteljau_nD!` up to order ``K-1`` and ``K-2`` respectively, and
 then the results are assembled by `_grad_Bα_from_Bαm!` and
 `_hess_Bα_from_Bαmm!` respectively. The implementation makes sure to only
-access each relevant ``B_β`` once per ``(∇/H)B_α`` computed. Also, on the
-reference simplex, the barycentric coordinates derivatives are computed at
-compile time using ``∂_qλ_i = δ_{i q}-δ_{i N}``.
+access each relevant ``B_β`` once per ``(∇/H)B_α`` computed.
 
 ## Bernstein basis generalization for ``\mathcal{P}Λ`` spaces
 
@@ -492,8 +489,11 @@ In the reference simplex ``\hat{T}``, the vertices and thus coefficients of
 ``ψ_I^{α,J}`` in ``\hat{T}``, denoted by ``\hat{m}_I^J`` and
 ``\hat{ψ}_I^{α,J}`` respectively, could be hard-coded at compile time in
 `@generated` functions to avoid storing them in the basis and accessing them at
-runtime. Let us derive the formulas for them.
+runtime.
 
+In the following, analytical formulas are derived for them. They are
+implemented and used in tests to validate the numerical computation of the
+coefficients.
 
 ##### Coefficients ``\hat{m}_I^J``
 

--- a/docs/src/modules/Polynomials.md
+++ b/docs/src/modules/Polynomials.md
@@ -301,11 +301,11 @@ BernsteinBasis(args...)
 ```@docs
 BernsteinBasis
 BernsteinBasisOnSimplex
-BernsteinBasisOnSimplex(::Val,::Type,::Int,vertices=nothing)
+BernsteinBasisOnSimplex(::Val,::Type,::Int)
 bernstein_terms
 bernstein_term_id
-BarycentricPmΛBasis(::Val{D},::Type{T},r,k,vertices=nothing; kwargs...) where {D,T}
-BarycentricPΛBasis(::Val{D},::Type{T},r,k,vertices=nothing; kwargs...) where {D,T}
+BarycentricPmΛBasis(::Val{D},::Type{T},r,k; kwargs...) where {D,T}
+BarycentricPΛBasis(::Val{D},::Type{T},r,k; kwargs...) where {D,T}
 ```
 ## Low level APIs and internals
 

--- a/src/Polynomials/BarycentricPΛBases.jl
+++ b/src/Polynomials/BarycentricPΛBases.jl
@@ -166,28 +166,28 @@ end
 ###########################################
 
 """
-    BarycentricPmΛBasis{D,V,LN,B} <: PolynomialBasis{D,V,Bernstein}
+    BarycentricPmΛBasis{D,V,LN,K} <: PolynomialBasis{D,V,Bernstein}
 
-Finite Element Exterior Calculus polynomial basis for the spaces P⁻`ᵣ`Λ`ᴷ` on
+Finite Element Exterior Calculus polynomial basis for the spaces P⁻`ᵣ`Λ`ᵏ` on
 `D`-dimensional simplices, but with polynomial forms explicitely transformed
 into vectors using the standard equivalence with usual vector calculus defined
 in terms of the hodge star operator ⋆ and the sharp map ♯, see
 [`_basis_forms_components`](@ref) (the simplex is assumed Euclidean).
 
 - `V` is `VectorValue{L,T}` where `L` is binomial(`D`,`k`),
-- `B` is the concrete type of the `BernsteinBasisOnSimplex` necessary for the evaluation of the polynomials.
+- `K` is the polynomial order of the underlying scalar bernstein polynomial basis
 
 The number of basis polynomials is binomial(`r`+`k`-1,`k`)*binomial(`D`+`r`,`D`-`k`) if no filtered bubble indices are given.
 
 Reference: D.N. Arnold, R.S. Falk & R. Winther, Geometric decompositions and local bases for spaces of finite element differential forms, CMAME, 2009
 """
-struct BarycentricPmΛBasis{D,V,LN,B} <: PolynomialBasis{D,V,Bernstein}
+struct BarycentricPmΛBasis{D,V,LN,K} <: PolynomialBasis{D,V,Bernstein}
   k::Int
-  scalar_bernstein_basis::B
+  scalar_bernstein_basis::BernsteinBasisOnSimplex{D,Float64,K}
   m::SVector{LN,V}
   _indices::BarycentricPΛIndices
 
-  function BarycentricPmΛBasis{D}(::Type{T}, r, k, vertices=nothing;
+  function BarycentricPmΛBasis{D}(::Type{T}, r, k, vertices;
         DG_calc=false, indices=nothing, rotate_90=false) where {D,T}
 
     FEEC_space_definition_checks(Val(D), T, r, k, :P⁻, rotate_90, DG_calc)
@@ -198,8 +198,8 @@ struct BarycentricPmΛBasis{D,V,LN,B} <: PolynomialBasis{D,V,Bernstein}
     L = binomial(D,k) # Number of components of a basis form
     V = VectorValue{L,T} # To update once DG_calc is implemented
 
-    b = BernsteinBasisOnSimplex{D}(T, r, vertices)
-    B = typeof(b)
+    b = BernsteinBasisOnSimplex{D}(Float64, r, vertices)
+    K = get_order(b)
     LN = binomial(D+1,k) # Number of k-faces J of a D-dimensional tetrahedron
     m = zero(MVector{LN,V})
     _compute_PmΛ_basis_coefficients!(m,Val(k),D,b,vertices,indices)
@@ -209,7 +209,7 @@ struct BarycentricPmΛBasis{D,V,LN,B} <: PolynomialBasis{D,V,Bernstein}
       m = reinterpret(T, m)
     end
 
-    new{D,V,LN,B}(k,b,m,indices)
+    new{D,V,LN,K}(k,b,m,indices)
   end
 
   @doc """
@@ -217,7 +217,7 @@ struct BarycentricPmΛBasis{D,V,LN,B} <: PolynomialBasis{D,V,Bernstein}
 
   Create a new basis which is `b` restricted to the bubble spaces for F ∈ `faces`.
   """
-  function BarycentricPmΛBasis(_b::BarycentricPmΛBasis{D,V,LN,B}, faces::Vector{Int}...) where {D,V,LN,B}
+  function BarycentricPmΛBasis(_b::BarycentricPmΛBasis{D,V,LN,K}, faces::Vector{Int}...) where {D,V,LN,K}
     # Notation: _old, new
     _indices = _b._indices
     _bubbles = _indices.bubbles
@@ -239,18 +239,20 @@ struct BarycentricPmΛBasis{D,V,LN,B} <: PolynomialBasis{D,V,Bernstein}
     end
 
     indices = BarycentricPΛIndices(_indices.identity, bubbles, _indices.components)
-    new{D,V,LN,B}(_b.k, _b.scalar_bernstein_basis, _b.m, indices)
+    new{D,V,LN,K}(_b.k, _b.scalar_bernstein_basis, _b.m, indices)
   end
 
-  function BarycentricPmΛBasis{D,V,LN,B}() where {D,V,LN,B} # just for testvalue
-    r = get_order(testvalue(B))
+  function BarycentricPmΛBasis{D,V,LN,K}() where {D,V,LN,K} # just for testvalue
+    r = K
     indices = _generate_or_check_PmΛ_indices(r,0,0,false,nothing,false)
-    new{D,V,LN,B}(0,testvalue(B),zero(SVector{LN,V}),indices)
+    B = BernsteinBasisOnSimplex{D,Float64,K}
+    new{D,V,LN,K}(0,testvalue(B),zero(SVector{LN,V}),indices)
   end
 end
 
 """
-    BarycentricPmΛBasis(::Val{D}, T, r, k, vertices=nothing; kwargs...)
+    BarycentricPmΛBasis(::Val{D}, T, r, k; kwargs...)
+    BarycentricPmΛBasis(::Val{D}, T, r, k, vertices; kwargs...)
 
 Constructors for [`BarycentricPmΛBasis`](@ref) of scalar type `T`.
 If `vertices` are specified, they must define a non-degenerate simplex, c.f. [`BernsteinBasisOnSimplex`](@ref).
@@ -260,9 +262,22 @@ The kwargs are the following:
 - `DG_calc = false`: set to `true` to choose `k`-form valued polynomials instead of vector valued polynomials (not implemented yet),
 - `rotate_90 = false`: In 2`D` for `k`=1, `true` to apply a 90° rotation of the vector proxied polynomials ((x,y) -> (-y,x)), needed for Raviart-Thomas/BDM.
 """
-function BarycentricPmΛBasis(::Val{D},::Type{T},r,k,vertices=nothing; kwargs...) where {D,T}
+function BarycentricPmΛBasis(::Val{D},::Type{T},r,k; kwargs...) where {D,T}
+  BarycentricPmΛBasis{D}(T,r,k; kwargs...)
+end
+function BarycentricPmΛBasis(::Val{D},::Type{T},r,k,vertices; kwargs...) where {D,T}
   BarycentricPmΛBasis{D}(T,r,k,vertices; kwargs...)
 end
+
+function BarycentricPmΛBasis{D}(::Type{T},r,k; kwargs...) where {D,T}
+  Pt = Point{D,Float64}
+  vertices = ntuple( j -> Pt( ntuple( i -> j==i+1, Val(D)) ), Val(D+1))
+  BarycentricPmΛBasis{D}(T,r,k,vertices; kwargs...)
+end
+
+@deprecate BarycentricPmΛBasis(::Val{D},::Type{T},r,k,::Nothing; kwargs...) where {D,T} BarycentricPmΛBasis(Val(D),T,r,k; kwargs...)
+@deprecate BarycentricPmΛBasis{D}(::Type{T},r,k,::Nothing; kwargs...) where {D,T} BarycentricPmΛBasis{D}(T,r,k; kwargs...)
+
 
 #get_FEEC_poly_degree(b::BarycentricPmΛBasis) = b.r
 #get_FEEC_form_degree(b::BarycentricPmΛBasis) = b.k
@@ -270,8 +285,8 @@ end
 
 Base.size(b::BarycentricPmΛBasis) = (_last_bubble_function_index(b._indices), )
 
-function testvalue(::Type{BarycentricPmΛBasis{D,V,LN,B}}) where {D,V,LN,B}
-  BarycentricPmΛBasis{D,V,LN,B}()
+function testvalue(::Type{BarycentricPmΛBasis{D,V,LN,K}}) where {D,V,LN,K}
+  BarycentricPmΛBasis{D,V,LN,K}()
 end
 
 ##########################################
@@ -279,9 +294,9 @@ end
 ##########################################
 
 """
-    BarycentricPΛBasis{D,V,C,B} <: PolynomialBasis{D,V,Bernstein}
+    BarycentricPΛBasis{D,V,C,K} <: PolynomialBasis{D,V,Bernstein}
 
-Finite Element Exterior Calculus polynomial basis for the spaces P`ᵣ`Λ`ᴷ` on
+Finite Element Exterior Calculus polynomial basis for the spaces P`ᵣ`Λ`ᵏ` on
 `D`-dimensional simplices, but with polynomial forms explicitely transformed
 into vectors using the standard equivalence with usual vector calculus defined
 in terms of the hodge star operator ⋆ and the sharp map ♯, see
@@ -289,19 +304,19 @@ in terms of the hodge star operator ⋆ and the sharp map ♯, see
 
 - `V` is `VectorValue{L,T}` where `L=binomial(D,k)`,
 - `C` is the number of basis polynomials,
-- `B` is the concrete type of the `BernsteinBasisOnSimplex` necessary for the evaluation of the polynomials.
+- `K` is the polynomial order of the underlying scalar bernstein polynomial basis
 
 `C` = binomial(`r`+`k`,`k`)*binomial(`D`+`r`,`D`-`k`) if no custom bubble indices are given.
 
 Reference: D.N. Arnold, R.S. Falk & R. Winther, Geometric decompositions and local bases for spaces of finite element differential forms, CMAME, 2009
 """
-struct BarycentricPΛBasis{D,V,C,B} <: PolynomialBasis{D,V,Bernstein}
+struct BarycentricPΛBasis{D,V,C,K} <: PolynomialBasis{D,V,Bernstein}
   k::Int
-  scalar_bernstein_basis::B
+  scalar_bernstein_basis::BernsteinBasisOnSimplex{D,Float64,K}
   Ψ::SVector{C,V}
   _indices::BarycentricPΛIndices
 
-  function BarycentricPΛBasis{D}(::Type{T}, r, k, vertices=nothing;
+  function BarycentricPΛBasis{D}(::Type{T}, r, k, vertices;
         DG_calc=false, indices=nothing, rotate_90=false) where {D,T}
 
     FEEC_space_definition_checks(Val(D), T, r, k, :P⁻, rotate_90, DG_calc)
@@ -313,8 +328,8 @@ struct BarycentricPΛBasis{D,V,C,B} <: PolynomialBasis{D,V,Bernstein}
     V = VectorValue{L,T} # To update once DG_calc is implemented
     C = _last_bubble_function_index(indices) # Cardinal of the basis
 
-    b = BernsteinBasisOnSimplex{D}(T, r, vertices)
-    B = typeof(b)
+    b = BernsteinBasisOnSimplex{D}(Float64, r, vertices)
+    K = get_order(b)
     Ψ = zero(MVector{C,V})
     _compute_PΛ_basis_form_coefficient!(Ψ,r,k,Val(D),b,vertices,indices)
 
@@ -323,7 +338,7 @@ struct BarycentricPΛBasis{D,V,C,B} <: PolynomialBasis{D,V,Bernstein}
       Ψ = reinterpret(T, Ψ)
     end
 
-    new{D,V,C,B}(k,b,Ψ,indices)
+    new{D,V,C,K}(k,b,Ψ,indices)
   end
 
   @doc """
@@ -333,8 +348,8 @@ struct BarycentricPΛBasis{D,V,C,B} <: PolynomialBasis{D,V,Bernstein}
   The faces are represented by some `Vector{Int}` of their vertices ids, like in
   [`BarycentricPΛIndices`](@ref).
   """
-  function BarycentricPΛBasis(_b::BarycentricPΛBasis{D,V,_C,B}, faces::Vector{Int}...) where {D,V,_C,B}
-    # Notation: _old, new
+  function BarycentricPΛBasis(_b::BarycentricPΛBasis{D,V,_C,K}, faces::Vector{Int}...) where {D,V,_C,K}
+    # Notation: _old, new
     _indices = _b._indices
     _bubbles = _indices.bubbles
     _Ψ = _b.Ψ
@@ -362,18 +377,19 @@ struct BarycentricPΛBasis{D,V,C,B} <: PolynomialBasis{D,V,Bernstein}
     C = w-1
     Ψ = SVector{C,V}( Ψ[1:C] )
     indices = BarycentricPΛIndices(_indices.identity, bubbles, _indices.components)
-    new{D,V,C,B}(_b.k, _b.scalar_bernstein_basis, Ψ, indices)
+    new{D,V,C,K}(_b.k, _b.scalar_bernstein_basis, Ψ, indices)
   end
 
-  function BarycentricPΛBasis{D,V,C,B}() where {D,V,C,B} # Just for testvalue
-    r = get_order(testvalue(B))
-    indices = _generate_or_check_PΛ_indices(r,0,0,false,nothing,false)
-    new{D,V,C,B}(0,testvalue(B),zero(SVector{C,V}),indices)
+  function BarycentricPΛBasis{D,V,C,K}() where {D,V,C,K} # Just for testvalue
+    indices = _generate_or_check_PΛ_indices(K,0,0,false,nothing,false)
+    B = BernsteinBasisOnSimplex{D,Float64,K}
+    new{D,V,C,K}(0,testvalue(B),zero(SVector{C,V}),indices)
   end
 end
 
 """
-    BarycentricPΛBasis(::Val{D}, T, r, k, vertices=nothing; kwargs...)
+    BarycentricPΛBasis(::Val{D}, T, r, k; kwargs...)
+    BarycentricPΛBasis(::Val{D}, T, r, k, vertices; kwargs...)
 
 Constructors for [`BarycentricPΛBasis`](@ref) of scalar type `T`.
 If `vertices` are specified, they must define a non-degenerate simplex, c.f. [`BernsteinBasisOnSimplex`](@ref).
@@ -383,9 +399,21 @@ The kwargs are the following:
 - `DG_calc = false`: set to `true` to choose `k`-form valued polynomials instead of vector valued polynomials (not implemented yet),
 - `rotate_90 = false`: In 2`D` for `k`=1, `true` to apply a 90° rotation of the vector proxied polynomials ((x,y) -> (-y,x)), needed for Raviart-Thomas/BDM.
 """
-function BarycentricPΛBasis(::Val{D},::Type{T},r,k,vertices=nothing; kwargs...) where {D,T}
+function BarycentricPΛBasis(::Val{D},::Type{T},r,k; kwargs...) where {D,T}
+  BarycentricPΛBasis{D}(T,r,k; kwargs...)
+end
+function BarycentricPΛBasis(::Val{D},::Type{T},r,k,vertices; kwargs...) where {D,T}
   BarycentricPΛBasis{D}(T,r,k,vertices; kwargs...)
 end
+
+function BarycentricPΛBasis{D}(::Type{T},r,k; kwargs...) where {D,T}
+  Pt = Point{D,Float64}
+  vertices = ntuple( j -> Pt( ntuple( i -> j==i+1, Val(D)) ), Val(D+1))
+  BarycentricPΛBasis{D}(T,r,k,vertices; kwargs...)
+end
+
+@deprecate BarycentricPΛBasis(::Val{D},::Type{T},r,k,::Nothing; kwargs...) where {D,T} BarycentricPΛBasis(Val(D),T,r,k; kwargs...)
+@deprecate BarycentricPΛBasis{D}(::Type{T},r,k,::Nothing; kwargs...) where {D,T} BarycentricPΛBasis{D}(T,r,k; kwargs...)
 
 #get_FEEC_poly_degree(b::BarycentricPΛBasis) = b.r
 #get_FEEC_form_degree(b::BarycentricPΛBasis) = b.k
@@ -393,8 +421,8 @@ end
 
 Base.size(::BarycentricPΛBasis{D,V,C}) where {D,V,C} = (C, )
 
-function testvalue(::Type{BarycentricPΛBasis{D,V,C,B}}) where {D,V,C,B}
-  BarycentricPΛBasis{D,V,C,B}()
+function testvalue(::Type{BarycentricPΛBasis{D,V,C,K}}) where {D,V,C,K}
+  BarycentricPΛBasis{D,V,C,K}()
 end
 
 ##########################
@@ -424,7 +452,7 @@ Prints the indices of `b` in a user friendly format into `out`.
 """
 print_indices(b::_BaryPΛBasis, out=stdout) = show(out, MIME"text/plain"(), b._indices)
 
-_get_cart_to_bary_matrix(b::_BaryPΛBasis) = b.scalar_bernstein_basis.cart_to_bary_matrix
+_get_x_to_λ(b::_BaryPΛBasis) = b.scalar_bernstein_basis.x_to_λ
 
 function _return_cache(b::_BaryPΛBasis,x,::Type{G},::Val{N_deriv}) where {G,N_deriv}
   T = eltype(G)
@@ -573,37 +601,11 @@ end
 
 function _compute_PmΛ_basis_coefficients!(m,::Val{k},D,b,vertices,indices) where k
   V = eltype(m)
-  M = transpose(b.cart_to_bary_matrix[:,2:end])
+  M = transpose(b.x_to_λ[:,2:end])
   m_J = Mutable(V)(undef)
   @inbounds for (J_id, J) in enumerate(_sorted_combinations(D+1,k))
     for (I_id, I, I_sgn) in indices.components
       m_J[I_id] = I_sgn * _minor(M,I,J,Val(k))
-    end
-    m[J_id] = m_J
-  end
-  nothing
-end
-
-function _compute_PmΛ_basis_coefficients!(
-  m,::Val{k},D,b,vertices::Nothing,indices) where k
-
-  if iszero(k) # so V is scalar, no change of basis
-    m .= 1
-    return nothing
-  end
-
-  V = eltype(m)
-  m_J = Mutable(V)(undef)
-  @inbounds for (J_id, J) in enumerate(_sorted_combinations(D+1,k))
-    s = Int(isone(J[1]))
-    for (I_id, I, I_sgn) in indices.components
-      n = count(i-> (J[i]-1)∉I, (1+s):k)
-      if iszero(n)
-        p = _findfirst_val_or_zero(j-> (I[j]+1)∉J, 1, k)
-        m_J[I_id] = I_sgn*_minusone_if_even_else_one(p+1)
-      else
-        m_J[I_id] = 0
-      end
     end
     m[J_id] = m_J
   end
@@ -618,7 +620,7 @@ function _evaluate_nd!(
   ::Val{r}) where {D,r}
 
   V = eltype(ω)
-  λ = _cart_to_bary(x, _get_cart_to_bary_matrix(b))
+  λ = _cart_to_bary(x, _get_x_to_λ(b))
 
   # _evaluate_nd!(::BernsteinBasisOnSimplex) without set_value
   cB[1] = 1
@@ -804,7 +806,7 @@ function _compute_PΛ_basis_form_coefficient!(Ψ,r,k,::Val{D},b,vertices,indices
 end
 
 @inline function _update_φ_αF!(φ_αF,b,α,F,r)
-  M = b.cart_to_bary_matrix
+  M = b.x_to_λ
   @inbounds for ci in CartesianIndices(φ_αF)
     i, j = ci[1], ci[2]
     mF = sum(M[Fl,i+1] for Fl in F; init=0)
@@ -821,91 +823,6 @@ function _order_0_Ψ!(Ψ)
   nothing
 end
 
-function _compute_PΛ_basis_form_coefficient!(
-  Ψ,r,k,::Val,b,vertices::Nothing,indices)
-
-  Vk = Val(k)
-  V = eltype(Ψ)
-  T = eltype(V)
-  Ψw = Mutable(V)(undef)
-
-  iszero(r) && return _order_0_Ψ!(Ψ)
-
-  @inbounds for (F, bubble_functions) in indices.bubbles
-    for (w, α, _, J) in bubble_functions
-      for (I_id, I, I_sgn) in indices.components
-        Ψw[I_id] = I_sgn * _hat_Ψ(r,Vk,α,F,I,J,T)
-      end
-      Ψ[w] = Ψw
-    end
-  end
-  nothing
-end
-
-"""
-    _hat_Ψ(r,::Val{k},α,F,I,J,T)::T
-
-BarycentricPΛBasis.Ψ matrix elements in the reference simplex, T is the scalar return type
-
-This is actually not faster than computing the matrices and the minors
-explicitely like when vertices are given, but might be usefull in case we want
-to compute these at compile time one day.
-"""
-function _hat_Ψ(r,Vk::Val{k},α,F,I,J,::Type{T})::T where {T,k}
-  @check sum(α) == r
-  @check length(I) == length(J) == k
-
-  iszero(k) && return one(T) # 0 forms
-
-  @inbounds begin
-
-    s = Int(isone(J[1]))
-    n = count(i-> (J[i]-1)∉I, (1+s):k)
-
-    n > 1 && return 0. # rank M_IJ inferior to 2
-
-    p = _findfirst_val_or_zero(j-> (I[j]+1)∉J, 1, k)
-
-    if isone(n)        # rank M_IJ is 1
-      m = _findfirst_val_or_zero(i-> (J[i]-1)∉I, (s+1), k)
-      u_p, v_m = _u(p,F,I), _v(m,α,J,r)
-      sgn = _minusone_if_even_else_one(m+p+1)
-      iszero(s) && return sgn*u_p*v_m
-
-      q = _findfirst_val_or_zero(j-> (I[j]+s)∉J, (p+1), k)
-      u_q = _u(q,F,I)
-      sgn *= _minusone_if_even_else_one(q+1)
-      return sgn * v_m * (u_q - u_p)
-    end
-
-    u, v = _u(F,I,Vk), _v(α,J,r,Vk)
-    if iszero(s)
-      return 1 + sum( u .* v )
-    else
-      Ψ_IJ = one(T)
-      sum_v = v[1]
-      for l in 1:p-1
-        vlp = v[l+1]
-        sum_v += vlp
-        Ψ_IJ += vlp*u[l]
-      end
-      for l in (p+1):k
-        vl = v[l]
-        sum_v += vl
-        Ψ_IJ += vl*u[l]
-      end
-      sgn = _minusone_if_even_else_one(p+1)
-      return sgn * (Ψ_IJ - u[p]*sum_v)
-    end
-
-  end
-  @unreachable
-end
-
-@propagate_inbounds _u(i::Int,F,I)   = Int(isone(F[1])) - Int(I[i]+1 in F)
-@propagate_inbounds _u(F::Vector{Int},I,Vk) = ntuple(i->_u(i,F,I), Vk)
-@propagate_inbounds _v(j::Int,α,J,r) = α[J[j]]/r
-@propagate_inbounds _v(α::Vector{Int},J,r,Vk) = ntuple(j->_v(j,α,J,r), Vk)
 
 # API
 
@@ -914,7 +831,7 @@ function _evaluate_nd!(
   ω::AbstractMatrix, i, cB,
   ::Val{r}) where {D,r}
 
-  λ = _cart_to_bary(x, _get_cart_to_bary_matrix(b))
+  λ = _cart_to_bary(x, _get_x_to_λ(b))
 
   # _evaluate_nd!(::BernsteinBasisOnSimplex) without set_value
   cB[1] = 1

--- a/src/Polynomials/BarycentricPΛBases.jl
+++ b/src/Polynomials/BarycentricPΛBases.jl
@@ -412,8 +412,8 @@ function BarycentricPΛBasis{D}(::Type{T},r,k; kwargs...) where {D,T}
   BarycentricPΛBasis{D}(T,r,k,vertices; kwargs...)
 end
 
-@deprecate BarycentricPΛBasis(::Val{D},::Type{T},r,k,::Nothing; kwargs...) where {D,T} BarycentricPΛBasis(Val(D),T,r,k; kwargs...)
-@deprecate BarycentricPΛBasis{D}(::Type{T},r,k,::Nothing; kwargs...) where {D,T} BarycentricPΛBasis{D}(T,r,k; kwargs...)
+BarycentricPΛBasis(::Val{D},::Type{T},r,k,::Nothing; kwargs...) where {D,T} = BarycentricPΛBasis(Val(D),T,r,k; kwargs...)
+BarycentricPΛBasis{D}(::Type{T},r,k,::Nothing; kwargs...) where {D,T} = BarycentricPΛBasis{D}(T,r,k; kwargs...)
 
 #get_FEEC_poly_degree(b::BarycentricPΛBasis) = b.r
 #get_FEEC_form_degree(b::BarycentricPΛBasis) = b.k

--- a/src/Polynomials/BernsteinBases.jl
+++ b/src/Polynomials/BernsteinBases.jl
@@ -270,12 +270,12 @@ used to compute the barycentric coordinates from, it must be non-degenerated
 (have nonzero volume). Otherwise, the coordinates of the reference simplex
 (`ExtrusionPolytope`) are used.
 """
-function BernsteinBasisOnSimplex(::Val{D}, ::Type{V}, order::Int, vertices) where {D,V}
-  BernsteinBasisOnSimplex{D}(V,order,vertices)
-end
-
 function BernsteinBasisOnSimplex(::Val{D}, ::Type{V}, order::Int) where {D,V}
   BernsteinBasisOnSimplex{D}(V,order)
+end
+
+function BernsteinBasisOnSimplex(::Val{D}, ::Type{V}, order::Int, vertices) where {D,V}
+  BernsteinBasisOnSimplex{D}(V,order,vertices)
 end
 
 function BernsteinBasisOnSimplex{D}(::Type{V}, order::Int) where {D,V}

--- a/src/Polynomials/BernsteinBases.jl
+++ b/src/Polynomials/BernsteinBases.jl
@@ -228,38 +228,35 @@ end
 ###################################################
 
 """
-    BernsteinBasisOnSimplex{D,V,M} <: PolynomialBasis{D,V,Bernstein}
+    BernsteinBasisOnSimplex{D,V,K} <: PolynomialBasis{D,V,Bernstein}
 
-Type for the multivariate Bernstein basis in barycentric coordinates,
-c.f. [Bernstein polynomials](@ref) section of the documentation. If `V` is not
-scalar, a duplication and direct sum of the scalar Bernstein basis is made for each
-independent component of `V`, yielding a basis of the Cartesian product space.
+Type for the multivariate Bernstein basis of order `K` in barycentric
+coordinates, c.f. [Bernstein polynomials](@ref) section of the documentation.
+If `V` is not scalar, a duplication and direct sum of the scalar Bernstein
+basis is made for each independent component of `V`, yielding a basis of the
+Cartesian product space.
 
 The index of `B_α` in the basis is [`bernstein_term_id(α)`](@ref bernstein_term_id).
 
-`M` is Nothing for the reference tetrahedra barycentric coordinates or
-`SMatrix{D+1,D+1}` if some simplex (triangle, tetrahedra, ...) vertices
-coordinates are given.
+# Fields
+- `x_to_λ::Matrix` the (D+1)×(D+1) change of coordinates matrix from cartesian to barycentric coordinates
 """
-struct BernsteinBasisOnSimplex{D,V,M,K} <: PolynomialBasis{D,V,Bernstein}
-  cart_to_bary_matrix::M #  Nothing or SMatrix{D+1,D+1}
+struct BernsteinBasisOnSimplex{D,V,K} <: PolynomialBasis{D,V,Bernstein}
+  x_to_λ::Matrix{Float64} # Hard-code Float64 as long as extrusion polytopes do it
 
-  function BernsteinBasisOnSimplex{D}(::Type{V},order::Int,vertices=nothing) where {D,V}
+  function BernsteinBasisOnSimplex{D}(::Type{V}, order::Int, vertices) where {D,V}
     _simplex_vertices_checks(Val(D), vertices)
 
     VV = make_concretetype(V)
-    cart_to_bary_matrix = _compute_cart_to_bary_matrix(vertices, Val(D+1))
-    M = typeof(cart_to_bary_matrix) # Nothing or SMatrix
+    x_to_λ = _compute_cart_to_bary_matrix(vertices, Val(D+1))
     K = order
-    new{D,VV,M,K}(cart_to_bary_matrix)
+    new{D,VV,K}(x_to_λ)
   end
 end
 
 function _simplex_vertices_checks(::Val{D}, vertices) where D
-  if !isnothing(vertices)
-    @check length(vertices) == D+1 "$D+1 vertices are required to define a $D-dim simplex, got $(length(vertices))"
-    @check eltype(vertices) <: Point{D} "Vertices should be of type <:Point{$D}, got $(eltype(vertices))"
-  end
+  @check length(vertices) == D+1 "$D+1 vertices are required to define a $D-dim simplex, got $(length(vertices))"
+  @check eltype(vertices) <: Point{D} "Vertices should be of type <:Point{$D}, got $(eltype(vertices))"
 end
 
 """
@@ -270,26 +267,34 @@ Constructors for [`BernsteinBasisOnSimplex`](@ref).
 
 If specified, `vertices` is a collection of `D+1` `Point{D}` defining a simplex
 used to compute the barycentric coordinates from, it must be non-degenerated
-(have nonzero volume).
+(have nonzero volume). Otherwise, the coordinates of the reference simplex
+(`ExtrusionPolytope`) are used.
 """
-function BernsteinBasisOnSimplex(::Val{D},::Type{V},order::Int,vertices=nothing) where {D,V}
+function BernsteinBasisOnSimplex(::Val{D}, ::Type{V}, order::Int, vertices) where {D,V}
   BernsteinBasisOnSimplex{D}(V,order,vertices)
 end
 
+function BernsteinBasisOnSimplex(::Val{D}, ::Type{V}, order::Int) where {D,V}
+  BernsteinBasisOnSimplex{D}(V,order)
+end
+
+function BernsteinBasisOnSimplex{D}(::Type{V}, order::Int) where {D,V}
+  Pt = Point{D,Float64}
+  vertices = ntuple( j -> Pt( ntuple( i -> j==i+1, Val(D)) ), Val(D+1))
+  BernsteinBasisOnSimplex{D}(V,order,vertices)
+end
+
+@deprecate BernsteinBasisOnSimplex{D}(::Type{V},order::Int,::Nothing) where {D,V} BernsteinBasisOnSimplex{D}(V,order)
+@deprecate BernsteinBasisOnSimplex(::Val{D},::Type{V},order::Int,::Nothing) where {D,V} BernsteinBasisOnSimplex(Val(D),V,order)
+
 Base.size(b::BernsteinBasisOnSimplex{D,V}) where {D,V} = (num_indep_components(V)*binomial(D+get_order(b),D),)
-get_order(::BernsteinBasisOnSimplex{D,V,M,K}) where {D,V,M,K} = K
+get_order(::BernsteinBasisOnSimplex{D,V,K}) where {D,V,K} = K
 get_orders(b::BernsteinBasisOnSimplex{D}) where D = tfill(get_order(b), Val(D))
 
-_get_parameters(::BernsteinBasisOnSimplex{D,V,M,K}) where {D,V,M,K} = Val(K)
+_get_parameters(::BernsteinBasisOnSimplex{D,V,K}) where {D,V,K} = Val(K)
 
-function testvalue(::Type{BernsteinBasisOnSimplex{D,V,M,K}}) where {D,V,M,K}
-  if M == Nothing
-    vertices = nothing
-  else
-    Pt = Point{D,eltype(M)}
-    vertices = ntuple( j -> Pt( ntuple( i -> j==i+1, Val(D)) ), Val(D+1))
-  end
-  BernsteinBasisOnSimplex{D}(V,K,vertices)
+function testvalue(::Type{BernsteinBasisOnSimplex{D,V,K}}) where {D,V,K}
+  BernsteinBasisOnSimplex{D}(V,K)
 end
 
 
@@ -299,11 +304,11 @@ end
 
 """
     _compute_cart_to_bary_matrix(vertices, ::Val{N})
-    _compute_cart_to_bary_matrix(::Nothing,::Val) = nothing
 
-For the given the vertices of a `D`-simplex (`D` = `N`-1), computes the change
+For the given vertices of a `D`-simplex (`D` = `N`-1), computes the change
 of coordinate matrix `x_to_λ` from cartesian to barycentric, such that
-`λ` = `x_to_λ` * `x` with `sum(λ) == 1` and `x == sum(λ .* vertices)`.
+`λ` = `x_to_λ` * `x_padded` with `sum(λ) == 1` and `x_padded == sum(λ .* vertices)`,
+and where `x_padded` is `Point(1, x...)` for any given Cartesian coordinates `x`.
 """
 function _compute_cart_to_bary_matrix(vertices, ::Val{N}) where N
   T = eltype(eltype(vertices))
@@ -316,19 +321,7 @@ function _compute_cart_to_bary_matrix(vertices, ::Val{N}) where N
   msg =  "The simplex defined by the given vertices is degenerated (is flat / has zero volume)."
   !all(isfinite, x_to_λ) && throw(DomainError(vertices,msg))
 
-  return SMatrix{N,N,T}(x_to_λ)
-end
-_compute_cart_to_bary_matrix(::Nothing, ::Val) = nothing
-
-"""
-    _cart_to_bary(x::Point{D,T}, ::Nothing)
-
-Compute the barycentric coordinates with respect to the reference simplex of the
-given cartesian coordinates `x`, that is `λ`=(x1, ..., xD, 1-x1-x2-...-xD).
-"""
-@inline function _cart_to_bary(x::Point{D,T}, ::Nothing) where {D,T}
-  sum_x = sum(x,init=zero(T))
-  return SVector(1-sum_x, x...)
+  return Matrix{Float64}(x_to_λ)
 end
 
 """
@@ -338,8 +331,10 @@ Compute the barycentric coordinates of the given cartesian coordinates `x` using
 the `x_to_λ` change of coordinate matrix, see [`_compute_cart_to_bary_matrix`](@ref).
 """
 @inline function _cart_to_bary(x::Point{D,T}, x_to_λ) where {D,T}
-  x_1 = SVector{D+1,T}(one(T), x...)
-  return x_to_λ*x_1
+  N = D+1
+  sx_to_λ = SizedMatrix{N,N,T}(x_to_λ)
+  x_1 = SVector{N,T}(one(T), x...)
+  return sx_to_λ*x_1
 end
 
 """
@@ -503,7 +498,7 @@ function _evaluate_nd!(
   r::AbstractMatrix, i,
   c::AbstractVector{T}, VK::Val) where {D,V,T}
 
-  λ = _cart_to_bary(x, b.cart_to_bary_matrix)
+  λ = _cart_to_bary(x, b.x_to_λ)
   c[1] = one(T)
   _downwards_de_Casteljau_nD!(c,λ,VK,Val(D))
 
@@ -520,7 +515,7 @@ function _gradient_nd!(
   g::Nothing,
   s::MVector{D,T}, ::Val{K}) where {D,V,G,T,K}
 
-  x_to_λ = b.cart_to_bary_matrix
+  x_to_λ = b.x_to_λ
   λ = _cart_to_bary(x, x_to_λ)
 
   c[1] = one(T)
@@ -537,7 +532,7 @@ function _hessian_nd!(
   h::Nothing,
   s::MMatrix{D,D,T}, ::Val{K}) where {D,V,G,T,K}
 
-  x_to_λ = b.cart_to_bary_matrix
+  x_to_λ = b.x_to_λ
   λ = _cart_to_bary(x, x_to_λ)
 
   c[1] = one(T)
@@ -556,7 +551,7 @@ coefficients.
 If `K0 = 1`, `λ` are the barycentric coordinates of some point `x` and `c[1] = 1`,
 this computes all order `K` basis Bernstein polynomials at `x`:
 
-`c[α_id] = B_α(x)  ∀α ∈ bernstein_terms(K,D)`
+`c[α_id] == B_α(x)  ∀α ∈ bernstein_terms(K,D)`
 
 where `α_id` = [`bernstein_term_id`](@ref)(α).
 """
@@ -639,7 +634,7 @@ end
 # ∂q(B_α) = K ∑_{1 ≤ i ≤ N} ∂q(λi) B_β
 # for  1 ≤ q ≤ D and β = α-ei
 @generated function _grad_Bα_from_Bαm!(
-    r,i,c,s,::Val{K},::Val{D},::Type{V},x_to_λ=nothing) where {K,D,V}
+    r,i,c,s,::Val{K},::Val{D},::Type{V},x_to_λ) where {K,D,V}
 
   ex_v = Vector{Expr}()
   ncomp = num_indep_components(V)
@@ -655,15 +650,10 @@ end
       push!(ex_v, :(@inbounds B_β = c[$id_β]))
       # s[q] = Σ_β ∂q(λi) B_β
       for q in 1:D
-        if x_to_λ == Nothing
-          # ∇λ(eq)_i = δ_{q+1,i} - δ_1i
-          Cqi = δ(i,q+1) - δ(1,i)
-          iszero(Cqi) || push!(ex_v, :(@inbounds s[$q] += $Cqi*B_β))
-        else
-          # ∂q(λi) = ei (x_to_λ*(e1 - e{q+1}) - x_to_λ*(e1)) = ei * x_to_λ * e{q+1}
-          # ∂q(λi) = x_to_λ[i,q+1]
-          push!(ex_v, :(@inbounds s[$q] += x_to_λ[$i,$(q+1)]*B_β))
-        end
+        # ∂q(λi) = ei (x_to_λ*(e1 - e{q+1}) - x_to_λ*(e1)) = ei * x_to_λ * e{q+1}
+        # ∂q(λi) = x_to_λ[i,q+1]
+        push!(ex_v, :(@inbounds s[$q] += x_to_λ[$i,$(q+1)]*B_β))
+        # On reference simplex, ∂q(λi) would be δ_{q+1,i} - δ_1i
       end
     end
     push!(ex_v, :(@inbounds s .*= $K)) # s = Ks.
@@ -678,7 +668,7 @@ end
 # ∂t(∂q(B_α)) = K(K-1) ∑_{1 ≤ i,j ≤ N} ∂t(λj) ∂q(λi) B_β
 # for  1 ≤ t,q ≤ D and β = α - ei - ej
 @generated function _hess_Bα_from_Bαmm!(
-    r,i,c,s,::Val{K},::Val{D},::Type{V},x_to_λ=nothing) where {K,D,V}
+    r,i,c,s,::Val{K},::Val{D},::Type{V},x_to_λ) where {K,D,V}
 
   ex_v = Vector{Expr}()
   ncomp = num_indep_components(V)
@@ -697,16 +687,14 @@ end
       push!(ex_v, :(@inbounds B_β = c[$id_β]))
       for t in 1:D
         for q in 1:D
-          if x_to_λ == Nothing
-          # s[t,q] = Σ_β B_β (δ_iq - δ_iN)*(δ_jt - δ_jN)
-                   Cβ  = C(q,t,i,j)
-            if i≠j Cβ += C(q,t,j,i) end
-            iszero(Cβ) || push!(ex_v, :(@inbounds s[$t,$q] += $Cβ*B_β))
-          else
-                   push!(ex_v, :(@inbounds C =  x_to_λ[$i,$(q+1)]*x_to_λ[$j,$(t+1)]))
-            if i≠j push!(ex_v, :(@inbounds C += x_to_λ[$j,$(q+1)]*x_to_λ[$i,$(t+1)])) end
-            push!(ex_v, :(@inbounds s[$t,$q] += C*B_β))
-          end
+                 push!(ex_v, :(@inbounds C =  x_to_λ[$i,$(q+1)]*x_to_λ[$j,$(t+1)]))
+          i≠j && push!(ex_v, :(@inbounds C += x_to_λ[$j,$(q+1)]*x_to_λ[$i,$(t+1)]))
+                 push!(ex_v, :(@inbounds s[$t,$q] += C*B_β))
+          # On reference simplex, this would be
+          ## s[t,q] = Σ_β B_β (δ_iq - δ_iN)*(δ_jt - δ_jN)
+          #         Cβ  = C(q,t,i,j)
+          #  if i≠j Cβ += C(q,t,j,i) end
+          #  iszero(Cβ) || push!(ex_v, :(@inbounds s[$t,$q] += $Cβ*B_β))
         end
       end
     end

--- a/src/Polynomials/BernsteinBases.jl
+++ b/src/Polynomials/BernsteinBases.jl
@@ -284,8 +284,8 @@ function BernsteinBasisOnSimplex{D}(::Type{V}, order::Int) where {D,V}
   BernsteinBasisOnSimplex{D}(V,order,vertices)
 end
 
-@deprecate BernsteinBasisOnSimplex{D}(::Type{V},order::Int,::Nothing) where {D,V} BernsteinBasisOnSimplex{D}(V,order)
-@deprecate BernsteinBasisOnSimplex(::Val{D},::Type{V},order::Int,::Nothing) where {D,V} BernsteinBasisOnSimplex(Val(D),V,order)
+BernsteinBasisOnSimplex{D}(::Type{V},order::Int,::Nothing) where {D,V} = BernsteinBasisOnSimplex{D}(V,order)
+BernsteinBasisOnSimplex(::Val{D},::Type{V},order::Int,::Nothing) where {D,V} = BernsteinBasisOnSimplex(Val(D),V,order)
 
 Base.size(b::BernsteinBasisOnSimplex{D,V}) where {D,V} = (num_indep_components(V)*binomial(D+get_order(b),D),)
 get_order(::BernsteinBasisOnSimplex{D,V,K}) where {D,V,K} = K

--- a/src/ReferenceFEs/GeometricDecompositions.jl
+++ b/src/ReferenceFEs/GeometricDecompositions.jl
@@ -126,7 +126,7 @@ function _are_barycoords_relative_to_simplex(
   @check is_simplex(simplex) && D == num_dims(simplex)
 
   vertices = get_vertex_coordinates(simplex)
-  M = b.cart_to_bary_matrix
+  M = b.x_to_λ
   vλ = [ Polynomials._cart_to_bary(v, M) for v in vertices ] # return SVectors ...
 
   T = eltype(eltype(vλ))

--- a/test/PolynomialsTests/BarycentricPΛBases.jl
+++ b/test/PolynomialsTests/BarycentricPΛBases.jl
@@ -63,6 +63,8 @@ end
 
 # Bases tests
 
+using Gridap.Polynomials: _minusone_if_even_else_one, _findfirst_val_or_zero
+
 function _test_testvalue(b, Bx, Gx, Hx)
   b0 = testvalue(b)
   @test b0 isa typeof(b)
@@ -71,6 +73,141 @@ function _test_testvalue(b, Bx, Gx, Hx)
   @test evaluate(Broadcasting(∇)(b0),x)  isa typeof(Gx)
   @test evaluate(Broadcasting(∇∇)(b0),x) isa typeof(Hx)
 end
+
+#############################################################################
+# Former logic with analytical computation of the basis in the Reference FE #
+#############################################################################
+
+function _test_reference_basis(b,D,r,k)
+  V = value_type(b)
+  V <: Real && (V = VectorValue{1,V})
+
+  if b isa BarycentricPmΛBasis
+    LN = binomial(D+1,k)
+    m = zero(MVector{LN,V})
+    _compute_PmΛ_basis_reference_coefficients!(m,k,D,b._indices)
+    @test all(@. norm(b.m - m) < 1.e-15)
+
+  else       #BarycentricPΛBasis
+    Ψ = zero(MVector{length(b),V})
+    _compute_PΛ_basis_reference_form_coefficient!(Ψ,r,k,b._indices)
+    @test all(@. norm(b.Ψ - Ψ) < 1.e-15)
+  end
+end
+
+function _compute_PmΛ_basis_reference_coefficients!(m,k,D,indices)
+
+  if iszero(k) # so V is scalar, no change of basis
+    m .= 1
+    return nothing
+  end
+
+  V = eltype(m)
+  m_J = Mutable(V)(undef)
+  @inbounds for (J_id, J) in enumerate(Polynomials._sorted_combinations(D+1,k))
+    s = Int(isone(J[1]))
+    for (I_id, I, I_sgn) in indices.components
+      n = count(i-> (J[i]-1)∉I, (1+s):k)
+      if iszero(n)
+        p = _findfirst_val_or_zero(j-> (I[j]+1)∉J, 1, k)
+        m_J[I_id] = I_sgn*_minusone_if_even_else_one(p+1)
+      else
+        m_J[I_id] = 0
+      end
+    end
+    m[J_id] = m_J
+  end
+  nothing
+end
+
+function _compute_PΛ_basis_reference_form_coefficient!(Ψ,r,k,indices)
+
+  """
+      _hat_Ψ(r,::Val{k},α,F,I,J,T)::T
+
+  BarycentricPΛBasis.Ψ matrix elements in the reference simplex, T is the scalar return type
+
+  This is actually not faster than computing the matrices and the minors
+  explicitely like when vertices are given, but might be usefull in case we want
+  to compute these at compile time one day.
+  """
+  function _hat_Ψ(r,Vk::Val{k},α,F,I,J,::Type{T})::T where {T,k}
+    @check sum(α) == r
+    @check length(I) == length(J) == k
+
+    iszero(k) && return one(T) # 0 forms
+
+    _u(i::Int,F,I)   = Int(isone(F[1])) - Int(I[i]+1 in F)
+    _u(F::Vector{Int},I,Vk) = ntuple(i->_u(i,F,I), Vk)
+    _v(j::Int,α,J,r) = α[J[j]]/r
+    _v(α::Vector{Int},J,r,Vk) = ntuple(j->_v(j,α,J,r), Vk)
+
+    @inbounds begin
+
+      s = Int(isone(J[1]))
+      n = count(i-> (J[i]-1)∉I, (1+s):k)
+
+      n > 1 && return 0. # rank M_IJ inferior to 2
+
+      p = _findfirst_val_or_zero(j-> (I[j]+1)∉J, 1, k)
+
+      if isone(n)        # rank M_IJ is 1
+        m = _findfirst_val_or_zero(i-> (J[i]-1)∉I, (s+1), k)
+        u_p, v_m = _u(p,F,I), _v(m,α,J,r)
+        sgn = _minusone_if_even_else_one(m+p+1)
+        iszero(s) && return sgn*u_p*v_m
+
+        q = _findfirst_val_or_zero(j-> (I[j]+s)∉J, (p+1), k)
+        u_q = _u(q,F,I)
+        sgn *= _minusone_if_even_else_one(q+1)
+        return sgn * v_m * (u_q - u_p)
+      end
+
+      u, v = _u(F,I,Vk), _v(α,J,r,Vk)
+      if iszero(s)
+        return 1 + sum( u .* v )
+      else
+        Ψ_IJ = one(T)
+        sum_v = v[1]
+        for l in 1:p-1
+          vlp = v[l+1]
+          sum_v += vlp
+          Ψ_IJ += vlp*u[l]
+        end
+        for l in (p+1):k
+          vl = v[l]
+          sum_v += vl
+          Ψ_IJ += vl*u[l]
+        end
+        sgn = _minusone_if_even_else_one(p+1)
+        return sgn * (Ψ_IJ - u[p]*sum_v)
+      end
+
+    end
+    @unreachable
+  end
+
+  Vk = Val(k)
+  V = eltype(Ψ)
+  T = eltype(V)
+  Ψw = Mutable(V)(undef)
+
+  iszero(r) && return _order_0_Ψ!(Ψ)
+
+  @inbounds for (F, bubble_functions) in indices.bubbles
+    for (w, α, _, J) in bubble_functions
+      for (I_id, I, I_sgn) in indices.components
+        Ψw[I_id] = I_sgn * _hat_Ψ(r,Vk,α,F,I,J,T)
+      end
+      Ψ[w] = Ψw
+    end
+  end
+  nothing
+end
+
+##############################
+# testing function and tests #
+##############################
 
 function _test_basis(VD::Val{D}, T, r, k, vertices) where D
   for PΛB in (BarycentricPmΛBasis, BarycentricPΛBasis)
@@ -86,6 +223,8 @@ function _test_basis(VD::Val{D}, T, r, k, vertices) where D
     faces = [bubble[1] for bubble in get_bubbles(b)] # bubble space selection
     b2  = PΛB(b, faces...)
     @test b == b2
+
+    _test_reference_basis(b,D,r,k)
 
     Bx = evaluate(b,x)
     Gx = evaluate(Broadcasting(∇)(b),x)

--- a/test/PolynomialsTests/BernsteinBasesTests.jl
+++ b/test/PolynomialsTests/BernsteinBasesTests.jl
@@ -13,11 +13,13 @@ using StaticArrays
 x = [Point(0.),Point(1.),Point(.4)]
 x1 = x[1]
 
+T = Float64
+
 #####################################
 # Tests for 1D Bernstein polynomial #
 #####################################
 
-V = Float64
+V = T
 G = gradient_type(V,x1)
 H = gradient_type(G,x1)
 
@@ -186,7 +188,7 @@ x = [Point(1.,0.), Point(.0,.5), Point(1.,.5), Point(.2,.3)]
 x3 = x[3]
 
 # scalar valued in 2D
-V = Float64
+V = T
 G = gradient_type(V,x3)
 H = gradient_type(G,x3)
 
@@ -228,19 +230,19 @@ test_field_array(b,x,bx,≈, grad=Gbx, gradgrad=Hbx)
 test_field_array(b,x[1],bx[1,:],≈,grad=Gbx[1,:],gradgrad=Hbx[1,:])
 
 b_terms = bernstein_terms(order,D)
-λ = Polynomials._cart_to_bary(x3, b.cart_to_bary_matrix)
+λ = Polynomials._cart_to_bary(x3, b.x_to_λ)
 for j in 1:length(b)
   α = b_terms[j]
   id_α = bernstein_term_id(α)
   @test id_α == j
-  c = Float64[ Int(i==id_α) for i in 1:length(b) ] # Bernstein coefficients of Bα
+  c = T[ Int(i==id_α) for i in 1:length(b) ] # Bernstein coefficients of Bα
   Polynomials._de_Casteljau_nD!(c, λ, Val(order), Val(D))
   Bα_x3 = c[1]
   @test Bα_x3 == bx[3,id_α]
 end
 
 # Vector valued in 2D
-V = VectorValue{3,Float64}
+V = VectorValue{3,T}
 G = gradient_type(V,x3)
 H = gradient_type(G,x3)
 
@@ -266,7 +268,7 @@ test_field_array(b,x[1],bx[1,:],grad=Gbx[1,:],gradgrad=Hbx[1,:])
 x = [Point(0.,0.,1.), Point(.5,.5,.5), Point(1.,.2,.4), Point(.2,.4,.3)]
 x1 = x[1]
 
-V = Float64
+V = T
 G = gradient_type(V,x1)
 H = gradient_type(G,x1)
 
@@ -283,12 +285,10 @@ test_field_array(b,x[1],bx[1,:],grad=Gbx[1,:],gradgrad=Hbx[1,:])
 ############################################################################
 # Tests for ND Bernstein polynomial with arbitrary barycentric coordinates #
 ############################################################################
-#
-T = Float64
 
 D = 0
 vertices = (Point(), )
-b = BernsteinBasisOnSimplex(Val(D), Float64, 3, vertices)
+b = BernsteinBasisOnSimplex(Val(D), T, 3, vertices)
 
 D = 2
 
@@ -297,16 +297,15 @@ vertices = (Point(0.,1.), Point(0.,2.), Point(0.,3.))
 
 vertices = (Point(5.,0.), Point(7.,2.), Point(0.,3.))
 
-b = BernsteinBasisOnSimplex(Val(D), Float64, 3, vertices)
+b = BernsteinBasisOnSimplex(Val(D), T, 3, vertices)
 x = [Point(.0,.5), Point(1.,.5), Point(.2,.3), Point(5.,0.), Point(7.,2.), Point(0.,3.)]
 x1 = x[1]
 
 for xi in x
-  λi = Polynomials._cart_to_bary(xi, b.cart_to_bary_matrix)
+  λi = Polynomials._cart_to_bary(xi, b.x_to_λ)
   @test sum(λi) ≈ 1.
   @test xi ≈ sum(λi .* vertices)
 end
-
 
 # Scalar value in 2D
 D = 2
@@ -333,7 +332,7 @@ x2λ = Polynomials._compute_cart_to_bary_matrix(vertices, Val(D+1))
 x = [Point(0.,0.,1.), Point(.5,.5,.5), Point(1.,.2,.4), Point(.2,.4,.3)]
 x1 = x[1]
 
-V = Float64
+V = T
 G = gradient_type(V,x1)
 H = gradient_type(G,x1)
 
@@ -346,8 +345,8 @@ test_field_array(b,x,bx,≈, grad=Gbx, gradgrad=Hbx)
 test_field_array(b,x1,bx[1,:],≈,grad=Gbx[1,:],gradgrad=Hbx[1,:])
 
 # value_type must be concrete even when user passes a non-concrete tensor type
-for V in (TensorValue{2,2,Float64}, SymTensorValue{2,Float64},
-          SkewSymTensorValue{2,Float64}, SymFourthOrderTensorValue{2,Float64})
+for V in (TensorValue{2,2,T}, SymTensorValue{2,T},
+          SkewSymTensorValue{2,T}, SymFourthOrderTensorValue{2,T})
   @test isconcretetype(value_type(BernsteinBasis(Val(2), V, 1)))
   @test isconcretetype(value_type(BernsteinBasisOnSimplex{2}(V, 1)))
 end

--- a/test/ReferenceFEsTests/ExtrusionPolytopesTests.jl
+++ b/test/ReferenceFEsTests/ExtrusionPolytopesTests.jl
@@ -1,6 +1,7 @@
 module ExtrusionPolytopesTests
 
 using Test
+using Gridap: Gridap
 using Gridap.Helpers
 using Gridap.TensorValues
 using Gridap.Arrays
@@ -179,21 +180,16 @@ for dim in 0:5
     @test is_simplex(p)
 end
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+# Check the consistency of the reference FE polytopes' coordinates with the
+# assumption of some polynomial bases, e.g. BernsteinBasisOnSimplex
+for D in 1:5
+  VD = Val(D)
+  ref_simplex = ExtrusionPolytope(tfill(TET_AXIS, VD))
+  vertex_coords = get_vertex_coordinates(ref_simplex)
+  b1 = Gridap.Polynomials.BernsteinBasisOnSimplex(VD, Float64, 0)
+  b2 = Gridap.Polynomials.BernsteinBasisOnSimplex(VD, Float64, 0, vertex_coords)
+  @test norm(b1.x_to_λ - b2.x_to_λ) < 1e-14
+end
 
 #using Gridap.Fields
 #


### PR DESCRIPTION
I removed the possibility of not storing a change of coordinate matrix (cartesian to barycentric) in BernsteinBasisOnSimplex.

This was an optimization for computations on reference simplices, but I realized it is complitely negligible and made the types of BernsteinBasisOnSimplex and BarycentricP(m)ΛBasis unecessarily complicated.

Now, the x_to_λ matrix is always stored, as a Matrix{Float64} instead of SMatrix, and SizedArray is used to cast the Matrix into a StaticArray to avoid allocations (and enable speed) in `_cart_to_bary`.

The Float64 hard-code leads to promotion to 64bits arithmetic for all evaluation of BernsteinBasisOnSimplex and P(m)Λ Bases. But the type parameters of both struct are way simpler now, the former B=BernsteinBasisOnSimplex{D,V,K} parameter is completely removed from P(m)Λ bases now.