### PR TITLE
fix TensorValues elementwise operation error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the dof signs flips for Curl conform reference FE bases for elements with `change_dof=true`. The signs are now tested for consistency with the `change_dof=false` version. Since PR [#1315](https://github.com/gridap/Gridap.jl/pull/1315).
 - Fixed evaluation of weak forms on empty trians with inverse maps. Since PR[#1316](https://github.com/gridap/Gridap.jl/pull/1316).
 - Fixed getting field type when changing domain on empty adapted triangulations. Since PR [#1326](https://github.com/gridap/Gridap.jl/pull/1326).
+- Fixed broadcasting of operation on `TensorValue{A,B}` components, and added broadcasting to `Third/HighOrderTensorValue`. Since PR [#1331](https://github.com/gridap/Gridap.jl/pull/1331).
 
 ### Changed
 - Changed `product_rule` to allow for numbers of `Complex` type. Since PR[#1325](https://github.com/gridap/Gridap.jl/pull/1325).

--- a/src/TensorValues/Operations.jl
+++ b/src/TensorValues/Operations.jl
@@ -1256,8 +1256,8 @@ function Base.broadcasted(f, a::VectorValue, b::VectorValue)
   VectorValue(map(f, a.data, b.data))
 end
 
-function Base.broadcasted(f, a::TensorValue, b::TensorValue)
-  TensorValue(map(f, a.data, b.data))
+function Base.broadcasted(f, a::TensorValue{D1,D2}, b::TensorValue{D1,D2}) where {D1,D2}
+  TensorValue{D1,D2}(map(f, a.data, b.data))
 end
 
 function Base.broadcasted(f, a::AbstractSymTensorValue, b::AbstractSymTensorValue)

--- a/src/TensorValues/Operations.jl
+++ b/src/TensorValues/Operations.jl
@@ -1263,3 +1263,7 @@ end
 function Base.broadcasted(f, a::AbstractSymTensorValue, b::AbstractSymTensorValue)
   SymTensorValue(map(f, a.data, b.data))
 end
+
+function Base.broadcasted(f, a::HighOrderTensorValue{S}, b::HighOrderTensorValue{S}) where S
+  HighOrderTensorValue{S}(map(f, a.data, b.data))
+end

--- a/test/TensorValuesTests/OperationsTests.jl
+++ b/test/TensorValuesTests/OperationsTests.jl
@@ -1356,12 +1356,7 @@ b = TensorValue{2,3,Int}(1,2,3,4,5,6)
 @test typeof(a .* b) == TensorValue{2,3,Float64,6}
 
 c = TensorValue{3,2,Int}(1,2,3,4,5,6)
-try
-  a .* c
-catch e
-  @test typeof(e) == ErrorException
-end
-
+@test_throws ErrorException a .* c
 
 a = SymTensorValue(1,2,4)
 b = SymTensorValue(1.,2.,4.)
@@ -1381,6 +1376,18 @@ c = a .* b
 
 a = SkewSymTensorValue(1,2,3)
 @test diag(a) == zero(VectorValue(1:3...))
+
+
+# Componant wise operations on tensor value of order > 2
+a = ThirdOrderTensorValue{1,3,2}(1,2,1,4,2,2)
+b = a .* a
+@test b == ThirdOrderTensorValue{1,3,2}(1,4,1,16,4,4)
+
+b = TensorValue{1,3,2,Float64}(1,2,3,4,5,6)
+@test typeof(a .* b) == TensorValue{2,3,Float64,6}
+
+c = TensorValue{3,2,Int}(1,2,3,4,5,6)
+@test_throws ErrorException a .* c
 
 # Operation involving empty tensors (check type promotion)
 

--- a/test/TensorValuesTests/OperationsTests.jl
+++ b/test/TensorValuesTests/OperationsTests.jl
@@ -1347,6 +1347,21 @@ c = a .* b
 
 @test diag(a) == VectorValue(1,4)
 
+a = TensorValue([1. 1. 1.; 2. 2. 2.])
+b = a .* a
+@test b == TensorValue([1. 1. 1.; 4. 4. 4.])
+@test typeof(b) == TensorValue{2,3,Float64,6}
+
+b = TensorValue{2,3,Int}(1,2,3,4,5,6)
+@test typeof(a .* b) == TensorValue{2,3,Float64,6}
+
+c = TensorValue{3,2,Int}(1,2,3,4,5,6)
+try
+  a .* c
+catch e
+  @test typeof(e) == ErrorException
+end
+
 
 a = SymTensorValue(1,2,4)
 b = SymTensorValue(1.,2.,4.)

--- a/test/TensorValuesTests/OperationsTests.jl
+++ b/test/TensorValuesTests/OperationsTests.jl
@@ -1383,10 +1383,10 @@ a = ThirdOrderTensorValue{1,3,2}(1,2,1,4,2,2)
 b = a .* a
 @test b == ThirdOrderTensorValue{1,3,2}(1,4,1,16,4,4)
 
-b = TensorValue{1,3,2,Float64}(1,2,3,4,5,6)
-@test typeof(a .* b) == TensorValue{2,3,Float64,6}
+b = ThirdOrderTensorValue{1,3,2,Float64}(1,2,3,4,5,6)
+@test typeof(a .* b) == ThirdOrderTensorValue{1,3,2,Float64,6}
 
-c = TensorValue{3,2,Int}(1,2,3,4,5,6)
+c = ThirdOrderTensorValue{1,2,3,Int}(1,2,3,4,5,6)
 @test_throws ErrorException a .* c
 
 # Operation involving empty tensors (check type promotion)


### PR DESCRIPTION
Hi @JordiManyer, I believe this is a bug:
```cmd
julia> using Gridap

julia> a = TensorValue([1. 2. 3.; 3. 2. 1.])
TensorValue{2, 3, Float64, 6}(1.0, 3.0, 2.0, 2.0, 3.0, 1.0)

julia> a .* a
ERROR: AssertionError: The number of scalar arguments in TensorValue has to be a perfect square (e.g., 1, 4, 9, 16, ...)
```
